### PR TITLE
Detecting root from runnable path to make the ext vscode workspace agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "windmill.additionalWorkspaces": {
           "order": 3,
           "type": "array",
-          "description": "The list of addutional remotes to use",
+          "description": "The list of additional remotes to use",
           "items": {
             "type": "object",
             "properties": {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as yaml from "js-yaml";
 import { extractInlineScripts } from "./flow";
+import { getRootPathFromRunnablePath } from "./helpers";
 import { FlowModule, OpenFlow } from "windmill-client";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -47,8 +48,9 @@ export function activate(context: vscode.ExtensionContext) {
     if (!editor) {
       return;
     }
-    const rootPath = vscode.workspace.getWorkspaceFolder(editor.document.uri)
-      ?.uri.path;
+
+    const rootPath = getRootPathFromRunnablePath(editor.document.uri.path) ||
+      vscode.workspace.getWorkspaceFolder(editor.document.uri)?.uri.path;
 
     if (!editor?.document.uri.path.includes(rootPath || "")) {
       return;
@@ -467,7 +469,7 @@ function getWebviewContent() {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Windmill</title>
       </head>
-    
+
       <body>
         Invalid remote: ${currentWorkspace} not found among the additionalRemotees
       </body>
@@ -498,7 +500,7 @@ function getWebviewContent() {
     const h1 = document.getElementById('foo');
 
     window.addEventListener('message', event => {
-        const message = event.data; 
+        const message = event.data;
         if (event.origin.startsWith('vscode-webview://')) {
           iframe.contentWindow?.postMessage(message, '*');
         } else {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -339,7 +339,7 @@ export function activate(context: vscode.ExtensionContext) {
           case "flow":
             // channel.appendLine("flow message");
             let uri = vscode.Uri.parse(message.uriPath);
-            if (!message.uriPath.endsWith("flow.yaml")) {
+            if (!message.uriPath?.endsWith("flow.yaml")) {
               return;
             }
             let dirPath = uri.toString().split("/").slice(0, -1).join("/");

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -6,15 +6,15 @@
     "/windmill/under/windmill-src/f/testing/bar.py" => "/windmill/under/windmill-src"
     "/windmill/free/windmill-src/u/ryan/bar.py" => "/windmill/free/windmill-src"
 */
-export function getRootPathFromRunnablePath(basePath: string): string {
+export function getRootPathFromRunnablePath(fullPath: string): string {
     const dirs = ["/u/", "/f/"];
 
     for (const dir of dirs) {
-        if (basePath.includes(dir)) {
-            basePath = basePath.endsWith(dir) ? basePath.split(dir)[0] : basePath.split(`${dir}`)[0];
+        if (fullPath.includes(dir)) {
+            fullPath = fullPath.endsWith(dir) ? fullPath.split(dir)[0] : fullPath.split(`${dir}`)[0];
             break;
         }
     }
 
-    return basePath;
+    return fullPath;
 }

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -1,15 +1,18 @@
-export function getRootPathFromRunnablePath(basePath: string) {
-    if (basePath.includes("/u/")) {
-        if (basePath.endsWith("/u")) {
-            basePath = basePath.split("/u")[0];
-        } else {
-            basePath = basePath.split("/u/")[0];
-        }
-    } else if (basePath.includes("/f")) {
-        if (basePath.endsWith("/f")) {
-            basePath = basePath.split("/f")[0];
-        } else {
-            basePath = basePath.split("/f/")[0];
+/*
+    This function takes in the path of a runnable and parses out the root path of the windmill project
+    Also accounts for multiple instances of "/u*" or "/f*" in the path
+
+    Examples:
+    "/windmill/under/windmill-src/f/testing/bar.py" => "/windmill/under/windmill-src"
+    "/windmill/free/windmill-src/u/ryan/bar.py" => "/windmill/free/windmill-src"
+*/
+export function getRootPathFromRunnablePath(basePath: string): string {
+    const dirs = ["/u/", "/f/"];
+
+    for (const dir of dirs) {
+        if (basePath.includes(dir)) {
+            basePath = basePath.endsWith(dir) ? basePath.split(dir)[0] : basePath.split(`${dir}`)[0];
+            break;
         }
     }
 

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -6,15 +6,14 @@
     "/windmill/under/windmill-src/f/testing/bar.py" => "/windmill/under/windmill-src"
     "/windmill/free/windmill-src/u/ryan/bar.py" => "/windmill/free/windmill-src"
 */
-export function getRootPathFromRunnablePath(fullPath: string): string {
+export function getRootPathFromRunnablePath(fullPath: string): string | undefined {
     const dirs = ["/u/", "/f/"];
 
     for (const dir of dirs) {
-        if (fullPath.includes(dir)) {
-            fullPath = fullPath.endsWith(dir) ? fullPath.split(dir)[0] : fullPath.split(`${dir}`)[0];
-            break;
+        if (fullPath.includes(dir) || fullPath.endsWith(dir) ) {
+            return fullPath.split(dir)[0];
         }
     }
 
-    return fullPath;
+    return;
 }

--- a/src/web/helpers.ts
+++ b/src/web/helpers.ts
@@ -1,0 +1,17 @@
+export function getRootPathFromRunnablePath(basePath: string) {
+    if (basePath.includes("/u/")) {
+        if (basePath.endsWith("/u")) {
+            basePath = basePath.split("/u")[0];
+        } else {
+            basePath = basePath.split("/u/")[0];
+        }
+    } else if (basePath.includes("/f")) {
+        if (basePath.endsWith("/f")) {
+            basePath = basePath.split("/f")[0];
+        } else {
+            basePath = basePath.split("/f/")[0];
+        }
+    }
+
+    return basePath;
+}


### PR DESCRIPTION
This PR allows an end user to not have to open VSCode in a specific working directory in order to use their runnables with shared common logic. 