### PR TITLE
Feature/pinning functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ The keybindings for that command are: Ctrl+Enter and Shift+Enter.
 ![image](./flows.png)
 
 ![demo](./demo.gif)
+
+## Development
+
+1. `npm install`
+2. `npm install -g vsce`
+3. `vsce package`
+4. `code --install-extension ./windmill-<version>.vsix` or `cursor --install-extension ./windmill-<version>.vsix`
+
+It is worth noting that sed works differently on Mac and Linux/Windows. The scripts below may need to be adjusted if you are on Mac.
+
+```
+{
+    "scripts": {
+       "switch-node": "sed -i '' 's/import { testBundle } from \".\\/esbuild.web\";/import { testBundle } from \".\\/esbuild\";/g' src/extension.ts",
+       "switch-web": "sed -i '' 's/import { testBundle } from \".\\/esbuild\";/import { testBundle } from \".\\/esbuild.web\";/g' src/extension.ts",
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "icon": "windmill.png",
   "publisher": "windmill-labs",
-  "version": "0.2.31",
+  "version": "0.2.34",
   "engines": {
     "vscode": "^1.79.0"
   },
@@ -51,6 +51,16 @@
       {
         "command": "windmill.addWorkspace",
         "title": "add a windmill workspace",
+        "category": "Windmill"
+      },
+      {
+        "command": "windmill.pinPreview",
+        "title": "Windmill: Pin Preview To File",
+        "category": "Windmill"
+      },
+      {
+        "command": "windmill.unpinPreview",
+        "title": "Windmill: Unpin Preview To File",
         "category": "Windmill"
       }
     ],
@@ -139,11 +149,11 @@
     "esbuild-base": "npm run switch-node && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --external:esbuild-wasm --external:esbuild --format=cjs --platform=node",
     "esbuild": "npm run switch-node && npm run esbuild-base -- --sourcemap",
     "watch": "npm run switch-node && tsc -watch -p ./",
-    "switch-node": "sed -i 's|import { testBundle } from \"./esbuild.web\";|import { testBundle } from \"./esbuild\";|g' src/extension.ts",
-    "switch-web": "sed -i 's|import { testBundle } from \"./esbuild\";|import { testBundle } from \"./esbuild.web\";|g' src/extension.ts",
+    "switch-node": "sed -i '' 's/import { testBundle } from \".\\/esbuild.web\";/import { testBundle } from \".\\/esbuild\";/g' src/extension.ts",
+    "switch-web": "sed -i '' 's/import { testBundle } from \".\\/esbuild\";/import { testBundle } from \".\\/esbuild.web\";/g' src/extension.ts",
     "compile-web": "npm run switch-web && webpack",
     "watch-web": "npm run switch-web && webpack --watch",
-    "package-web": "npm run switch-web && webpack --mode production",
+    "package-web": "npm run switch-web && webpack --mode production --config webpack.config.js",
     "lint": "eslint src --ext ts",
     "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
   },


### PR DESCRIPTION
Add pinning of files to keep from losing variables in the iframe when changing editors. 

Functionality:

1. A pinned file does not reload iframe when switching editors.
2. Pinning a new file, when one exists, works as expected.
3. If a file is pinned and no preview is open it opens one. 
4. On closing the preview it unpins. 

Note:
- I didn't increment package.json as I'm not sure when you'll release next. 
- I added a note about getting developing up and rolling as I had never worked on a VSCode extension. 