### PR TITLE
fix: handle inline scripts in failure_module and preprocessor_module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "windmill",
-  "version": "0.2.56",
+  "version": "0.2.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windmill",
-      "version": "0.2.56",
+      "version": "0.2.58",
       "dependencies": {
         "@stoplight/yaml": "^4.3.0",
         "esbuild-wasm": "^0.23.0",
         "minimatch": "^9.0.4",
         "tar-stream": "^3.1.7",
         "windmill-client": "^1.659.1",
-        "windmill-utils-internal": "^1.3.6",
+        "windmill-utils-internal": "^1.3.8",
         "windmill-yaml-validator": "^1.1.1",
         "yaml": "^2.8.0"
       },
@@ -7709,9 +7709,9 @@
       "license": "Apache 2.0"
     },
     "node_modules/windmill-utils-internal": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/windmill-utils-internal/-/windmill-utils-internal-1.3.6.tgz",
-      "integrity": "sha512-bc7lefMLEhfRTiCIhIDrsIAD4p5pw0V9uD6yroeeqS31YqQWJYvuu4kPBB/DiU23PcJJiWqKKv0WyhY8TCe+pg==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/windmill-utils-internal/-/windmill-utils-internal-1.3.8.tgz",
+      "integrity": "sha512-FtVEvAI2PIqPTEpowTjo5c5JkYe09Scu9zcwzJutOWMEh4aDdzOejaG7EZTac0pk+dK4JB46+nbl82hhLsL8Mw==",
       "license": "Apache 2.0"
     },
     "node_modules/windmill-yaml-validator": {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "minimatch": "^9.0.4",
     "tar-stream": "^3.1.7",
     "windmill-client": "^1.659.1",
-    "windmill-utils-internal": "^1.3.6",
+    "windmill-utils-internal": "^1.3.8",
     "windmill-yaml-validator": "^1.1.1",
     "yaml": "^2.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "icon": "windmill.png",
   "publisher": "windmill-labs",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -597,13 +597,19 @@ export function activate(context: vscode.ExtensionContext) {
             }
             await Promise.all(
               allExtracted.map(async (s) => {
+                let inlineUri = vscode.Uri.parse(dirPath + "/" + s.path);
+                let exists = await fileExists(inlineUri);
+
                 if (s.content.startsWith("!inline ")) {
-                  channel.appendLine("Skipping write of unresolved inline reference: " + s.path);
+                  if (!exists) {
+                    await vscode.workspace.fs.writeFile(
+                      inlineUri,
+                      new TextEncoder().encode("")
+                    );
+                  }
                   return;
                 }
                 let encoded = new TextEncoder().encode(s.content);
-                let inlineUri = vscode.Uri.parse(dirPath + "/" + s.path);
-                let exists = await fileExists(inlineUri);
 
                 if (
                   !exists ||
@@ -616,8 +622,6 @@ export function activate(context: vscode.ExtensionContext) {
                     inlineUri,
                     new TextEncoder().encode(s.content)
                   );
-                } else {
-                  // channel.appendLine("same content");
                 }
               })
             );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
   replaceAllPathScriptsWithLocal,
   extractInlineScripts,
   extractCurrentMapping,
+  newPathAssigner,
 } from "windmill-utils-internal";
 import { getGitHeadPath } from "./utils/git-utils";
 import { GitBranchConfig } from "./config/config-manager";
@@ -208,16 +209,24 @@ export function activate(context: vscode.ExtensionContext) {
               error: (...args: any[]) => channel.appendLine(args.join(" ")),
             };
 
+          const inlineFileReader = async (path: string) => {
+            const fpath =
+              uriPath.split("/").slice(0, -1).join("/") + "/" + path;
+            return await readTextFromUri(vscode.Uri.parse(fpath));
+          };
+
           await replaceInlineScripts(
             flow?.value?.modules,
-            async (path) => {
-              const fpath =
-                uriPath.split("/").slice(0, -1).join("/") + "/" + path;
-              return await readTextFromUri(vscode.Uri.parse(fpath));
-            },
+            inlineFileReader,
             flowLogger,
             uriPath
           );
+          if (flow?.value?.failure_module) {
+            await replaceInlineScripts([flow.value.failure_module], inlineFileReader, flowLogger, uriPath);
+          }
+          if (flow?.value?.preprocessor_module) {
+            await replaceInlineScripts([flow.value.preprocessor_module], inlineFileReader, flowLogger, uriPath);
+          }
 
           // Replace PathScript modules with local file content so previews use local versions
           if (flow?.value) {
@@ -519,15 +528,18 @@ export function activate(context: vscode.ExtensionContext) {
             return;
           case "flow":
             let currentLoadedFlow: FlowModule[] | undefined = undefined;
+            let currentLoadedFailureModule: FlowModule | undefined = undefined;
+            let currentLoadedPreprocessorModule: FlowModule | undefined = undefined;
 
             try {
               if (lastFlowDocument) {
-                currentLoadedFlow = (
-                  parseYamlWithInline(lastFlowDocument?.getText() || "") as any
-                )?.["value"]?.["modules"] as FlowModule[];
+                const parsedFlow = parseYamlWithInline(lastFlowDocument?.getText() || "") as any;
+                currentLoadedFlow = parsedFlow?.["value"]?.["modules"] as FlowModule[];
                 if (!Array.isArray(currentLoadedFlow)) {
                   currentLoadedFlow = undefined;
                 }
+                currentLoadedFailureModule = parsedFlow?.["value"]?.["failure_module"] as FlowModule | undefined;
+                currentLoadedPreprocessorModule = parsedFlow?.["value"]?.["preprocessor_module"] as FlowModule | undefined;
               }
             } catch {}
 
@@ -545,16 +557,44 @@ export function activate(context: vscode.ExtensionContext) {
 
             let dirPath = uri.toString().split("/").slice(0, -1).join("/");
             let inlineScriptMapping = {};
-            extractCurrentMapping(currentLoadedFlow, inlineScriptMapping);
+            extractCurrentMapping(
+              currentLoadedFlow,
+              inlineScriptMapping,
+              currentLoadedFailureModule,
+              currentLoadedPreprocessorModule
+            );
+
+            const extractOptions = { skipInlineScriptSuffix: lastNonDottedPaths };
+            const pathAssigner = newPathAssigner(lastDefaultTs ?? "bun", extractOptions);
 
             const allExtracted = extractInlineScripts(
               message?.flow?.value?.modules ?? [],
               inlineScriptMapping,
               "/",
               lastDefaultTs ?? "bun",
-              undefined,
-              { skipInlineScriptSuffix: lastNonDottedPaths }
+              pathAssigner,
+              extractOptions
             );
+            if (message?.flow?.value?.failure_module?.value?.type === "rawscript") {
+              allExtracted.push(...extractInlineScripts(
+                [message.flow.value.failure_module],
+                inlineScriptMapping,
+                "/",
+                lastDefaultTs ?? "bun",
+                pathAssigner,
+                extractOptions
+              ));
+            }
+            if (message?.flow?.value?.preprocessor_module?.value?.type === "rawscript") {
+              allExtracted.push(...extractInlineScripts(
+                [message.flow.value.preprocessor_module],
+                inlineScriptMapping,
+                "/",
+                lastDefaultTs ?? "bun",
+                pathAssigner,
+                extractOptions
+              ));
+            }
             await Promise.all(
               allExtracted.map(async (s) => {
                 let encoded = new TextEncoder().encode(s.content);
@@ -568,7 +608,7 @@ export function activate(context: vscode.ExtensionContext) {
                     await vscode.workspace.fs.readFile(inlineUri)
                   )
                 ) {
-                  vscode.workspace.fs.writeFile(
+                  await vscode.workspace.fs.writeFile(
                     inlineUri,
                     new TextEncoder().encode(s.content)
                   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,14 +212,7 @@ export function activate(context: vscode.ExtensionContext) {
           const inlineFileReader = async (path: string) => {
             const fpath =
               uriPath.split("/").slice(0, -1).join("/") + "/" + path;
-            const fileUri = vscode.Uri.parse(fpath);
-            const openDoc = vscode.workspace.textDocuments.find(
-              (d) => d.uri.toString() === fileUri.toString()
-            );
-            if (openDoc) {
-              return openDoc.getText();
-            }
-            return await readTextFromUri(fileUri);
+            return await readTextFromUri(vscode.Uri.parse(fpath));
           };
 
           await replaceInlineScripts(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -597,6 +597,10 @@ export function activate(context: vscode.ExtensionContext) {
             }
             await Promise.all(
               allExtracted.map(async (s) => {
+                if (s.content.startsWith("!inline ")) {
+                  channel.appendLine("Skipping write of unresolved inline reference: " + s.path);
+                  return;
+                }
                 let encoded = new TextEncoder().encode(s.content);
                 let inlineUri = vscode.Uri.parse(dirPath + "/" + s.path);
                 let exists = await fileExists(inlineUri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,7 +212,14 @@ export function activate(context: vscode.ExtensionContext) {
           const inlineFileReader = async (path: string) => {
             const fpath =
               uriPath.split("/").slice(0, -1).join("/") + "/" + path;
-            return await readTextFromUri(vscode.Uri.parse(fpath));
+            const fileUri = vscode.Uri.parse(fpath);
+            const openDoc = vscode.workspace.textDocuments.find(
+              (d) => d.uri.toString() === fileUri.toString()
+            );
+            if (openDoc) {
+              return openDoc.getText();
+            }
+            return await readTextFromUri(fileUri);
           };
 
           await replaceInlineScripts(

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -11,6 +11,12 @@ export async function fileExists(uri: vscode.Uri): Promise<boolean> {
 }
 
 export async function readTextFromUri(uri: vscode.Uri): Promise<string> {
+  const openDoc = vscode.workspace.textDocuments.find(
+    (d) => d.uri.toString() === uri.toString()
+  );
+  if (openDoc) {
+    return openDoc.getText();
+  }
   const bytes = await vscode.workspace.fs.readFile(uri);
   return new TextDecoder().decode(bytes);
 }


### PR DESCRIPTION
## Summary
- Resolve `!inline` references in `failure_module` and `preprocessor_module` when loading flows (previously only main modules were processed, causing literal `!inline id.ts` text to appear in the webview)
- Extract inline scripts from `failure_module`/`preprocessor_module` when saving flows, matching the CLI's behavior (`flow.ts:167-172`, `flow_metadata.ts:249-261`)
- Fix race condition: `await` the `writeFile` calls so inline script files are on disk before `onDidChangeTextDocument` triggers a refresh
- Guard against writing unresolved `!inline` content to script files: create an empty file if it doesn't exist yet, preserve existing content otherwise
- Bump `windmill-utils-internal` to `^1.3.8`

## Test plan
- [x] Existing tests pass (`npm test` — 47/47)
- [x] Build succeeds (`npm run esbuild`)
- [ ] Open a flow with a `failure_module` containing an inline script — verify content displays correctly instead of `!inline failure.ts`
- [ ] Edit and save a flow with failure/preprocessor modules — verify inline script files are created and the YAML references are correct
- [ ] Verify that an unresolved `!inline` reference does not overwrite an existing script file on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)