### PR TITLE
fix: read the `workspaces` key from wmill.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test-web/
 *.vsix
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,7 @@ module.exports = {
   "transform": {
     "^.+\\.(ts|tsx)$": "ts-jest"
   },
+  "moduleNameMapper": {
+    "^vscode$": "<rootDir>/src/test/vscode-stub.ts"
+  },
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "icon": "windmill.png",
   "publisher": "windmill-labs",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/config/branch-profiles.ts
+++ b/src/config/branch-profiles.ts
@@ -1,0 +1,64 @@
+import { getConfigDirPath } from "windmill-utils-internal";
+
+// The CLI stores this under getStore("") — the config dir plus the hex of
+// hash_string(""), which is 0 (see the CLI's core/store.ts).
+const BRANCH_PROFILES_DIR = "0";
+const BRANCH_PROFILES_FILE = "branch-profiles.json";
+
+type BranchProfileMapping = {
+  lastUsed?: {
+    // key format: "<workspaceName>|<baseUrl>|<workspaceId>" -> profile name
+    [key: string]: string;
+  };
+};
+
+/**
+ * Key of a remembered profile choice. Must match the CLI's
+ * getBranchProfileKey (core/branch-profiles.ts), including the URL
+ * normalization, or we'd look up entries the CLI never wrote.
+ */
+export function getBranchProfileKey(
+  workspaceName: string,
+  baseUrl: string,
+  workspaceId: string
+): string {
+  let normalizedUrl: string;
+  try {
+    normalizedUrl = new URL(baseUrl).toString();
+  } catch {
+    normalizedUrl = baseUrl;
+  }
+  return `${workspaceName}|${normalizedUrl}|${workspaceId}`;
+}
+
+/**
+ * The profile the CLI last used for this workspace, when several profiles
+ * share a remote and workspace id. Read-only: the CLI owns this file, and
+ * following its choice keeps both tools on the same identity.
+ *
+ * Returns undefined when there is no remembered choice, the file is absent or
+ * unreadable, or we're running in a web environment without file access.
+ */
+export async function getLastUsedProfile(
+  workspaceName: string,
+  baseUrl: string,
+  workspaceId: string,
+  configFolder?: string
+): Promise<string | undefined> {
+  if (typeof process === "undefined" || !process.versions || !process.versions.node) {
+    return undefined;
+  }
+
+  try {
+    const fs = await import("fs");
+    const folder = configFolder && configFolder.length > 0 ? configFolder : undefined;
+    const configDir = await getConfigDirPath(folder);
+    const path = `${configDir}${BRANCH_PROFILES_DIR}/${BRANCH_PROFILES_FILE}`;
+
+    const mapping = JSON.parse(fs.readFileSync(path, "utf8")) as BranchProfileMapping;
+    return mapping?.lastUsed?.[getBranchProfileKey(workspaceName, baseUrl, workspaceId)];
+  } catch (error) {
+    // Missing file, invalid JSON, no read access: fall back to the caller's default
+    return undefined;
+  }
+}

--- a/src/config/config-manager.ts
+++ b/src/config/config-manager.ts
@@ -4,12 +4,83 @@ import { minimatch } from "minimatch";
 import { fileExists, readTextFromUri } from "../utils/file-utils";
 import { Codebase } from "../extension";
 
-export type GitBranchConfig = {
-  [branchName: string]: {
-    baseUrl: string;
-    workspaceId: string;
-  };
+/** A single entry of the `workspaces` map in wmill.yaml. */
+export type WorkspaceEntryConfig = {
+  baseUrl?: string;
+  /** Git branch this workspace is bound to. Defaults to the workspace name. */
+  gitBranch?: string;
+  /** Windmill workspace id. Defaults to the workspace name. */
+  workspaceId?: string;
 };
+
+/** The `workspaces` map of wmill.yaml, keyed by workspace name. */
+export type WorkspacesConfig = {
+  [workspaceName: string]: WorkspaceEntryConfig;
+};
+
+// Deprecated aliases of `workspaces`, in the same priority order the CLI uses.
+const LEGACY_WORKSPACES_KEYS = [
+  "gitBranches",
+  "environments",
+  "git_branches",
+] as const;
+
+// Keys of the `workspaces` map that are not workspaces.
+const RESERVED_WORKSPACE_KEYS = new Set(["commonSpecificItems"]);
+
+/**
+ * Read the workspaces map out of a parsed wmill.yaml, falling back to the
+ * deprecated keys. Returns the raw map plus the key it came from, for logging.
+ */
+export function extractWorkspacesConfig(
+  config: any
+): { key: string; workspaces: WorkspacesConfig } | undefined {
+  for (const key of ["workspaces", ...LEGACY_WORKSPACES_KEYS]) {
+    const workspaces = config?.[key];
+    if (workspaces && typeof workspaces === "object") {
+      return { key, workspaces: workspaces as WorkspacesConfig };
+    }
+  }
+  return undefined;
+}
+
+/** The git branch a workspace entry is bound to (defaults to its name). */
+export function getEffectiveGitBranch(
+  workspaceName: string,
+  entry: WorkspaceEntryConfig
+): string {
+  return entry.gitBranch ?? workspaceName;
+}
+
+/** The Windmill workspace id of a workspace entry (defaults to its name). */
+export function getEffectiveWorkspaceId(
+  workspaceName: string,
+  entry: WorkspaceEntryConfig
+): string {
+  return entry.workspaceId ?? workspaceName;
+}
+
+/**
+ * Find the workspace entry bound to a git branch. In the legacy format the keys
+ * were branch names and `gitBranch` was absent, so this handles both.
+ */
+export function findWorkspaceByGitBranch(
+  workspaces: WorkspacesConfig | undefined,
+  branchName: string
+): [string, WorkspaceEntryConfig] | undefined {
+  if (!workspaces) {
+    return undefined;
+  }
+  for (const [name, entry] of Object.entries(workspaces)) {
+    if (RESERVED_WORKSPACE_KEYS.has(name) || !entry || typeof entry !== "object") {
+      continue;
+    }
+    if (getEffectiveGitBranch(name, entry) === branchName) {
+      return [name, entry];
+    }
+  }
+  return undefined;
+}
 
 export function findCodebase(
   path: string,
@@ -66,7 +137,7 @@ export async function loadConfigForPath(
 ): Promise<{
   defaultTs: "deno" | "bun";
   codebases: any[];
-  gitBranches?: GitBranchConfig;
+  workspaces?: WorkspacesConfig;
   nonDottedPaths: boolean;
 }> {
   let splittedSlash = wmPath.split("/");
@@ -74,7 +145,7 @@ export async function loadConfigForPath(
   let found = false;
   let defaultTs: "deno" | "bun" = "bun";
   let codebases: any[] = [];
-  let gitBranches: GitBranchConfig | undefined = undefined;
+  let workspaces: WorkspacesConfig | undefined = undefined;
   let nonDottedPaths = false;
 
   for (let i = 0; i < splittedSlash.length; i++) {
@@ -88,7 +159,8 @@ export async function loadConfigForPath(
       let config = (yaml.parse(content) ?? {}) as any;
       defaultTs = config?.["defaultTs"] ?? "bun";
       codebases = config?.["codebases"] ?? [];
-      gitBranches = config?.["gitBranches"];
+      const workspacesConfig = extractWorkspacesConfig(config);
+      workspaces = workspacesConfig?.workspaces;
       nonDottedPaths = config?.["nonDottedPaths"] === true;
       channel.appendLine(
         path +
@@ -96,8 +168,10 @@ export async function loadConfigForPath(
           defaultTs +
           ", codebases:" +
           JSON.stringify(codebases) +
-          ", gitBranches:" +
-          JSON.stringify(gitBranches) +
+          ", " +
+          (workspacesConfig?.key ?? "workspaces") +
+          ":" +
+          JSON.stringify(workspaces) +
           ", nonDottedPaths:" +
           nonDottedPaths
       );
@@ -110,5 +184,5 @@ export async function loadConfigForPath(
     codebases = [];
   }
 
-  return { defaultTs, codebases, gitBranches, nonDottedPaths };
+  return { defaultTs, codebases, workspaces, nonDottedPaths };
 }

--- a/src/config/config-manager.ts
+++ b/src/config/config-manager.ts
@@ -125,7 +125,10 @@ export function findCodebase(
         excluded = true;
       }
     }
-    return included && !excluded ? c : undefined;
+    // Keep looking through the remaining codebases, like the CLI's findCodebase
+    if (included && !excluded) {
+      return c;
+    }
   }
   return undefined;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,6 +131,7 @@ export function activate(context: vscode.ExtensionContext) {
   let pinnedFileUri: vscode.Uri | undefined = undefined;
   let lastWorkspacesConfig: WorkspacesConfig | undefined = undefined;
   let gitHeadWatcher: vscode.FileSystemWatcher | undefined = undefined;
+  let wmillYamlWatcher: vscode.FileSystemWatcher | undefined = undefined;
 
   async function refreshPanel(
     editor: vscode.TextEditor | undefined,
@@ -328,8 +329,9 @@ export function activate(context: vscode.ExtensionContext) {
         lastWorkspacesConfig = result.config;
       }
 
-      // Step 3: Setup git watcher
+      // Step 3: Setup watchers
       await setupGitBranchWatcher();
+      await setupWmillYamlWatcher();
     } catch (error) {
       channel.appendLine(`Error initializing workspace: ${error}`);
       console.error("Error initializing workspace:", error);
@@ -364,52 +366,85 @@ export function activate(context: vscode.ExtensionContext) {
         new vscode.RelativePattern(workspaceFolders[0], ".git/HEAD")
       );
 
-      // Watch for changes to .git/HEAD (which happens on branch switch)
-      gitHeadWatcher.onDidChange(async () => {
-        channel.appendLine("Git HEAD changed, re-syncing config and checking for workspace switch");
+      const onGitHeadChanged = async (rsn: string) => {
+        channel.appendLine(`${rsn}, re-syncing config and checking for workspace switch`);
         // Re-sync CLI config before checking branch
         await syncVSCodeConfigFromCLI(channel);
-        
-        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastWorkspacesConfig);
-        if (result.config) {
-          lastWorkspacesConfig = result.config;
-        }
+        await applyWorkspaceForCurrentBranch();
+      };
 
-        // Refresh the panel if it's open and workspace was switched
-        if (result.switched && currentPanel) {
-          channel.appendLine("Refreshing panel with new workspace configuration");
-          currentPanel.webview.html = getWebviewContent();
-          if (lastActiveEditor) {
-            refreshPanel(lastActiveEditor, "workspace switch from git branch");
-          }
-        }
-      });
+      // Watch for changes to .git/HEAD (which happens on branch switch)
+      gitHeadWatcher.onDidChange(() => onGitHeadChanged("Git HEAD changed"));
 
       // Also watch for onCreate since git sometimes replaces the file
-      gitHeadWatcher.onDidCreate(async () => {
-        channel.appendLine("Git HEAD created, re-syncing config and checking for workspace switch");
-        // Re-sync CLI config before checking branch
-        await syncVSCodeConfigFromCLI(channel);
-        
-        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastWorkspacesConfig);
-        if (result.config) {
-          lastWorkspacesConfig = result.config;
-        }
-        
-        // Refresh the panel if it's open and workspace was switched
-        if (result.switched && currentPanel) {
-          channel.appendLine("Refreshing panel with new workspace configuration");
-          currentPanel.webview.html = getWebviewContent();
-          if (lastActiveEditor) {
-            refreshPanel(lastActiveEditor, "workspace switch from git branch");
-          }
-        }
-      });
+      gitHeadWatcher.onDidCreate(() => onGitHeadChanged("Git HEAD created"));
 
       context.subscriptions.push(gitHeadWatcher);
     } catch (error) {
       channel.appendLine(`Error setting up git branch watcher: ${error}`);
       console.error("Error setting up git branch watcher:", error);
+    }
+  }
+
+  /**
+   * Re-check the current git branch against wmill.yaml and switch workspace if
+   * it maps to a different one, refreshing the panel when it does.
+   */
+  async function applyWorkspaceForCurrentBranch() {
+    const result = await checkAndSwitchWorkspaceForGitBranch(
+      channel,
+      lastWorkspacesConfig
+    );
+    if (result.config) {
+      lastWorkspacesConfig = result.config;
+    }
+
+    // Refresh the panel if it's open and workspace was switched
+    if (result.switched && currentPanel) {
+      channel.appendLine("Refreshing panel with new workspace configuration");
+      currentPanel.webview.html = getWebviewContent();
+      if (lastActiveEditor) {
+        refreshPanel(lastActiveEditor, "workspace switch from git branch");
+      }
+    }
+  }
+
+  /**
+   * The workspaces config is cached and otherwise only reloaded when the active
+   * editor changes, so edits to wmill.yaml would not take effect until then.
+   */
+  async function setupWmillYamlWatcher() {
+    try {
+      if (wmillYamlWatcher) {
+        wmillYamlWatcher.dispose();
+        wmillYamlWatcher = undefined;
+      }
+
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders || workspaceFolders.length === 0) {
+        channel.appendLine("No workspace folder found for wmill.yaml watcher");
+        return;
+      }
+
+      wmillYamlWatcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(workspaceFolders[0], "**/wmill.yaml")
+      );
+
+      const onWmillYamlChanged = async (uri: vscode.Uri) => {
+        channel.appendLine(`${uri.path} changed, reloading workspace configuration`);
+        // Drop the cache so the branch check re-reads wmill.yaml
+        lastWorkspacesConfig = undefined;
+        await applyWorkspaceForCurrentBranch();
+      };
+
+      wmillYamlWatcher.onDidChange(onWmillYamlChanged);
+      wmillYamlWatcher.onDidCreate(onWmillYamlChanged);
+      wmillYamlWatcher.onDidDelete(onWmillYamlChanged);
+
+      context.subscriptions.push(wmillYamlWatcher);
+    } catch (error) {
+      channel.appendLine(`Error setting up wmill.yaml watcher: ${error}`);
+      console.error("Error setting up wmill.yaml watcher:", error);
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ import {
   newPathAssigner,
 } from "windmill-utils-internal";
 import { getGitHeadPath } from "./utils/git-utils";
-import { GitBranchConfig } from "./config/config-manager";
+import { WorkspacesConfig } from "./config/config-manager";
 import { createLocalScriptReader } from "./utils/local-path-scripts";
 import {
   snapshotPathScripts,
@@ -129,7 +129,7 @@ export function activate(context: vscode.ExtensionContext) {
   let lastNonDottedPaths = false;
   let codebaseFound: Codebase | undefined = undefined;
   let pinnedFileUri: vscode.Uri | undefined = undefined;
-  let lastGitBranchConfig: GitBranchConfig | undefined = undefined;
+  let lastWorkspacesConfig: WorkspacesConfig | undefined = undefined;
   let gitHeadWatcher: vscode.FileSystemWatcher | undefined = undefined;
 
   async function refreshPanel(
@@ -195,7 +195,7 @@ export function activate(context: vscode.ExtensionContext) {
       codebaseFound = cpath.endsWith(".ts")
         ? findCodebase(wmPath, configResult.codebases)
         : undefined;
-      lastGitBranchConfig = configResult.gitBranches;
+      lastWorkspacesConfig = configResult.workspaces;
     }
 
     const lang = determineLanguage(cpath, lastDefaultTs);
@@ -322,10 +322,10 @@ export function activate(context: vscode.ExtensionContext) {
       channel.appendLine("Checking git branch for workspace switch...");
       const result = await checkAndSwitchWorkspaceForGitBranch(
         channel,
-        lastGitBranchConfig
+        lastWorkspacesConfig
       );
       if (result.config) {
-        lastGitBranchConfig = result.config;
+        lastWorkspacesConfig = result.config;
       }
 
       // Step 3: Setup git watcher
@@ -370,9 +370,9 @@ export function activate(context: vscode.ExtensionContext) {
         // Re-sync CLI config before checking branch
         await syncVSCodeConfigFromCLI(channel);
         
-        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastGitBranchConfig);
+        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastWorkspacesConfig);
         if (result.config) {
-          lastGitBranchConfig = result.config;
+          lastWorkspacesConfig = result.config;
         }
 
         // Refresh the panel if it's open and workspace was switched
@@ -391,9 +391,9 @@ export function activate(context: vscode.ExtensionContext) {
         // Re-sync CLI config before checking branch
         await syncVSCodeConfigFromCLI(channel);
         
-        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastGitBranchConfig);
+        const result = await checkAndSwitchWorkspaceForGitBranch(channel, lastWorkspacesConfig);
         if (result.config) {
-          lastGitBranchConfig = result.config;
+          lastWorkspacesConfig = result.config;
         }
         
         // Refresh the panel if it's open and workspace was switched
@@ -432,10 +432,10 @@ export function activate(context: vscode.ExtensionContext) {
       channel.appendLine("Checking git branch for workspace switch...");
       const gitBranchResult = await checkAndSwitchWorkspaceForGitBranch(
         channel,
-        lastGitBranchConfig
+        lastWorkspacesConfig
       );
       if (gitBranchResult.config) {
-        lastGitBranchConfig = gitBranchResult.config;
+        lastWorkspacesConfig = gitBranchResult.config;
       }
       channel.appendLine(`Git branch workspace switch: ${gitBranchResult.switched}`);
     } catch (e) {

--- a/src/test/branch-profiles.test.ts
+++ b/src/test/branch-profiles.test.ts
@@ -1,0 +1,21 @@
+import { getBranchProfileKey } from "../config/branch-profiles";
+
+describe("getBranchProfileKey", () => {
+  it("matches the key format the CLI writes", () => {
+    // Shape taken from a real branch-profiles.json written by the CLI
+    expect(getBranchProfileKey("test", "https://internal.windmill.dev/", "test")).toBe(
+      "test|https://internal.windmill.dev/|test"
+    );
+  });
+
+  it("normalizes the base URL the same way the CLI does", () => {
+    // A wmill.yaml baseUrl without a trailing slash must hit the same entry
+    expect(getBranchProfileKey("test", "https://internal.windmill.dev", "test")).toBe(
+      "test|https://internal.windmill.dev/|test"
+    );
+  });
+
+  it("falls back to the raw value for an unparseable URL", () => {
+    expect(getBranchProfileKey("cm", "not a url", "cm")).toBe("cm|not a url|cm");
+  });
+});

--- a/src/test/branch-profiles.test.ts
+++ b/src/test/branch-profiles.test.ts
@@ -1,4 +1,25 @@
-import { getBranchProfileKey } from "../config/branch-profiles";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { getBranchProfileKey, getLastUsedProfile } from "../config/branch-profiles";
+
+// The CLI writes this file under getStore(""), i.e. the config dir plus the hex
+// of hash_string(""), which is 0. Verified against a real CLI-written file.
+let configFolder: string;
+
+function writeBranchProfiles(contents: string) {
+  const dir = path.join(configFolder, "windmill", "0");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "branch-profiles.json"), contents, "utf8");
+}
+
+beforeEach(() => {
+  configFolder = fs.mkdtempSync(path.join(os.tmpdir(), "wm-vscode-profiles-"));
+});
+
+afterEach(() => {
+  fs.rmSync(configFolder, { recursive: true, force: true });
+});
 
 describe("getBranchProfileKey", () => {
   it("matches the key format the CLI writes", () => {
@@ -17,5 +38,49 @@ describe("getBranchProfileKey", () => {
 
   it("falls back to the raw value for an unparseable URL", () => {
     expect(getBranchProfileKey("cm", "not a url", "cm")).toBe("cm|not a url|cm");
+  });
+});
+
+describe("getLastUsedProfile", () => {
+  const REMOTE = "https://windmill.example.net/";
+
+  it("reads the profile the CLI remembered", async () => {
+    writeBranchProfiles(
+      JSON.stringify({ lastUsed: { [`cm|${REMOTE}|cm`]: "cm-service" } })
+    );
+
+    expect(await getLastUsedProfile("cm", REMOTE, "cm", configFolder)).toBe("cm-service");
+  });
+
+  it("finds the entry from a baseUrl without a trailing slash", async () => {
+    writeBranchProfiles(
+      JSON.stringify({ lastUsed: { [`cm|${REMOTE}|cm`]: "cm-service" } })
+    );
+
+    expect(
+      await getLastUsedProfile("cm", "https://windmill.example.net", "cm", configFolder)
+    ).toBe("cm-service");
+  });
+
+  it("returns undefined for a workspace with no remembered choice", async () => {
+    writeBranchProfiles(JSON.stringify({ lastUsed: { [`ir|${REMOTE}|ir`]: "ir" } }));
+
+    expect(await getLastUsedProfile("cm", REMOTE, "cm", configFolder)).toBeUndefined();
+  });
+
+  it("returns undefined when the file does not exist", async () => {
+    expect(await getLastUsedProfile("cm", REMOTE, "cm", configFolder)).toBeUndefined();
+  });
+
+  it("returns undefined when the file is not valid JSON", async () => {
+    writeBranchProfiles("{not json}");
+
+    expect(await getLastUsedProfile("cm", REMOTE, "cm", configFolder)).toBeUndefined();
+  });
+
+  it("returns undefined when the file has no lastUsed map", async () => {
+    writeBranchProfiles(JSON.stringify({}));
+
+    expect(await getLastUsedProfile("cm", REMOTE, "cm", configFolder)).toBeUndefined();
   });
 });

--- a/src/test/cli-config-sync.test.ts
+++ b/src/test/cli-config-sync.test.ts
@@ -1,0 +1,162 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  getWorkspacesFromConfig,
+  syncVSCodeConfigFromCLI,
+} from "../workspace/workspace-manager";
+import {
+  __configuration,
+  __failConfigurationUpdates,
+  __outputChannel,
+  __resetConfiguration,
+} from "./vscode-stub";
+
+// The CLI config is read through node's fs, so these run against a real
+// temporary config dir laid out the way the CLI writes it.
+let configFolder: string;
+
+function writeCliConfig(remotes: any[], active: string) {
+  const dir = path.join(configFolder, "windmill");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "remotes.ndjson"),
+    remotes.map((r) => JSON.stringify(r)).join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(path.join(dir, "activeWorkspace"), active, "utf8");
+}
+
+const CM = {
+  name: "cm-prod",
+  remote: "https://windmill.example.net/",
+  workspaceId: "cm",
+  token: "token-cm",
+};
+const IR = {
+  name: "ir",
+  remote: "https://windmill.example.net/",
+  workspaceId: "ir",
+  token: "token-ir",
+};
+
+beforeEach(() => {
+  configFolder = fs.mkdtempSync(path.join(os.tmpdir(), "wm-vscode-test-"));
+  __resetConfiguration({ configFolder });
+  // The missing/invalid config cases log to console.error by design
+  jest.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  fs.rmSync(configFolder, { recursive: true, force: true });
+});
+
+describe("getWorkspacesFromConfig", () => {
+  it("reads the workspaces and the active one", async () => {
+    writeCliConfig([CM, IR], "ir");
+
+    expect(await getWorkspacesFromConfig(configFolder)).toEqual({
+      workspaces: [CM, IR],
+      active: "ir",
+    });
+  });
+
+  it("ignores blank lines and a trailing newline", async () => {
+    const dir = path.join(configFolder, "windmill");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "remotes.ndjson"),
+      `${JSON.stringify(CM)}\n\n${JSON.stringify(IR)}\n`,
+      "utf8"
+    );
+    fs.writeFileSync(path.join(dir, "activeWorkspace"), "cm-prod", "utf8");
+
+    const { workspaces } = await getWorkspacesFromConfig(configFolder);
+    expect(workspaces).toEqual([CM, IR]);
+  });
+
+  it("returns nothing when the config files are missing", async () => {
+    expect(await getWorkspacesFromConfig(configFolder)).toEqual({
+      workspaces: [],
+      active: "",
+    });
+  });
+
+  it("returns nothing when a line is not valid JSON", async () => {
+    const dir = path.join(configFolder, "windmill");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "remotes.ndjson"), "{not json}", "utf8");
+    fs.writeFileSync(path.join(dir, "activeWorkspace"), "cm-prod", "utf8");
+
+    expect(await getWorkspacesFromConfig(configFolder)).toEqual({
+      workspaces: [],
+      active: "",
+    });
+  });
+});
+
+describe("syncVSCodeConfigFromCLI", () => {
+  it("copies the active workspace into the VSCode settings", async () => {
+    writeCliConfig([CM, IR], "ir");
+
+    const result = await syncVSCodeConfigFromCLI(__outputChannel());
+    expect(result.synced).toBe(true);
+    expect(result.workspaces).toEqual([CM, IR]);
+
+    const conf = __configuration();
+    expect(conf.remote).toBe(IR.remote);
+    expect(conf.workspaceId).toBe(IR.workspaceId);
+    expect(conf.token).toBe(IR.token);
+    expect(conf.currentWorkspace).toBe("ir");
+    // Every CLI profile becomes selectable, not just the active one
+    expect(conf.additionalWorkspaces).toEqual([CM, IR]);
+  });
+
+  it("does not sync when the active workspace is not in the list", async () => {
+    writeCliConfig([CM], "deleted-profile");
+
+    const result = await syncVSCodeConfigFromCLI(__outputChannel());
+    expect(result.synced).toBe(false);
+    // The workspaces are still reported, but nothing is written
+    expect(result.workspaces).toEqual([CM]);
+    expect(__configuration().currentWorkspace).toBeUndefined();
+    expect(__configuration().additionalWorkspaces).toBeUndefined();
+  });
+
+  it("does not sync when there is no CLI config", async () => {
+    const result = await syncVSCodeConfigFromCLI(__outputChannel());
+    expect(result).toEqual({ workspaces: [], synced: false });
+    expect(__configuration().currentWorkspace).toBeUndefined();
+  });
+
+  it("leaves an existing VSCode workspace selection alone when there is no CLI config", async () => {
+    __resetConfiguration({ configFolder, currentWorkspace: "manually-configured" });
+
+    await syncVSCodeConfigFromCLI(__outputChannel());
+    expect(__configuration().currentWorkspace).toBe("manually-configured");
+  });
+
+  it("reports a failed settings write instead of throwing", async () => {
+    writeCliConfig([CM, IR], "ir");
+    __failConfigurationUpdates(new Error("settings are read-only"));
+
+    const channel = __outputChannel();
+    expect(await syncVSCodeConfigFromCLI(channel)).toEqual({
+      workspaces: [],
+      synced: false,
+    });
+    expect(
+      channel.lines.some((l: string) => l.includes("settings are read-only"))
+    ).toBe(true);
+  });
+
+  it("logs what it synced", async () => {
+    writeCliConfig([CM, IR], "ir");
+
+    const channel = __outputChannel();
+    await syncVSCodeConfigFromCLI(channel);
+    expect(channel.lines).toContain("Synced 2 workspace(s) from CLI config");
+    expect(channel.lines).toContain("Active workspace: ir");
+  });
+});

--- a/src/test/find-codebase.test.ts
+++ b/src/test/find-codebase.test.ts
@@ -1,0 +1,52 @@
+import { findCodebase } from "../config/config-manager";
+
+describe("findCodebase", () => {
+  it("matches a codebase without includes", () => {
+    const codebase = {};
+    expect(findCodebase("f/foo/bar.ts", [codebase])).toBe(codebase);
+  });
+
+  it("matches on an includes glob", () => {
+    const codebase = { includes: ["f/foo/**"] };
+    expect(findCodebase("f/foo/bar.ts", [codebase])).toBe(codebase);
+    expect(findCodebase("f/other/bar.ts", [codebase])).toBeUndefined();
+  });
+
+  it("accepts includes and excludes given as a bare string", () => {
+    expect(findCodebase("f/foo/bar.ts", [{ includes: "f/foo/**" }])).toBeDefined();
+    expect(
+      findCodebase("f/foo/bar.ts", [{ includes: "f/foo/**", excludes: "**/bar.ts" }])
+    ).toBeUndefined();
+  });
+
+  it("stops at the first matching includes glob", () => {
+    const codebase = { includes: ["f/foo/**", "f/other/**"] };
+    expect(findCodebase("f/foo/bar.ts", [codebase])).toBe(codebase);
+  });
+
+  it("rejects an excluded path", () => {
+    const codebase = { includes: ["f/foo/**"], excludes: ["f/foo/skip/**"] };
+    expect(findCodebase("f/foo/keep/x.ts", [codebase])).toBe(codebase);
+    expect(findCodebase("f/foo/skip/x.ts", [codebase])).toBeUndefined();
+  });
+
+  it("keeps looking past a codebase that does not match", () => {
+    // The CLI's findCodebase scans every codebase; stopping at the first one
+    // made any codebase after it unreachable.
+    const first = { includes: ["f/first/**"] };
+    const second = { includes: ["f/second/**"] };
+
+    expect(findCodebase("f/second/bar.ts", [first, second])).toBe(second);
+  });
+
+  it("returns the first of several matching codebases", () => {
+    const first = { includes: ["f/**"] };
+    const second = { includes: ["f/foo/**"] };
+
+    expect(findCodebase("f/foo/bar.ts", [first, second])).toBe(first);
+  });
+
+  it("returns undefined when there are no codebases", () => {
+    expect(findCodebase("f/foo/bar.ts", [])).toBeUndefined();
+  });
+});

--- a/src/test/git-utils.test.ts
+++ b/src/test/git-utils.test.ts
@@ -1,0 +1,141 @@
+import {
+  getCurrentGitBranch,
+  getGitDir,
+  getGitHeadPath,
+} from "../utils/git-utils";
+import { __DIRECTORY, __setFileSystem, __setWorkspaceFolders } from "./vscode-stub";
+
+const ROOT = "file:///repo";
+
+beforeEach(() => {
+  __setWorkspaceFolders([ROOT]);
+  __setFileSystem();
+});
+
+describe("getCurrentGitBranch", () => {
+  it("reads the branch from .git/HEAD", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBe("main");
+  });
+
+  it("supports branch names containing slashes", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/wm-fork/main/abc\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBe("wm-fork/main/abc");
+  });
+
+  it("returns undefined on a detached HEAD", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "9fceb02d0ae598e95dc970b74767f19372d61af8\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+
+  it("returns undefined outside a git repository", async () => {
+    __setFileSystem({ [`${ROOT}/wmill.yaml`]: "defaultTs: bun" });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+
+  it("returns undefined when HEAD is missing", async () => {
+    __setFileSystem({ [`${ROOT}/.git`]: __DIRECTORY });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+
+  it("returns undefined without a workspace folder", async () => {
+    __setWorkspaceFolders([]);
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+
+  it("returns undefined when HEAD cannot be read", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      // Present, but unreadable as text
+      [`${ROOT}/.git/HEAD`]: __DIRECTORY,
+    });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+    jest.restoreAllMocks();
+  });
+
+  it("tolerates trailing whitespace in HEAD", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "  ref: refs/heads/main  \n\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBe("main");
+  });
+});
+
+describe("getCurrentGitBranch in a worktree", () => {
+  it("follows an absolute gitdir pointer", async () => {
+    __setFileSystem({
+      // In a worktree, .git is a file pointing at the real git dir
+      [`${ROOT}/.git`]: "gitdir: /repo/.git/worktrees/feature\n",
+      ["file:///repo/.git/worktrees/feature/HEAD"]: "ref: refs/heads/feature\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBe("feature");
+  });
+
+  it("follows a gitdir pointer relative to the workspace folder", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: "gitdir: ../main-checkout/.git/worktrees/feature\n",
+      ["file:///main-checkout/.git/worktrees/feature/HEAD"]: "ref: refs/heads/feature\n",
+    });
+
+    expect(await getCurrentGitBranch()).toBe("feature");
+  });
+
+  it("returns undefined when the .git file is not a gitdir pointer", async () => {
+    __setFileSystem({ [`${ROOT}/.git`]: "not a gitdir pointer\n" });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+
+  it("returns undefined when the pointed-at git dir has no HEAD", async () => {
+    __setFileSystem({ [`${ROOT}/.git`]: "gitdir: /repo/.git/worktrees/gone\n" });
+
+    expect(await getCurrentGitBranch()).toBeUndefined();
+  });
+});
+
+describe("getGitDir and getGitHeadPath", () => {
+  it("resolves the git directory and its HEAD", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+    });
+
+    expect((await getGitDir())?.toString()).toBe(`${ROOT}/.git`);
+    expect((await getGitHeadPath())?.toString()).toBe(`${ROOT}/.git/HEAD`);
+  });
+
+  it("resolves HEAD inside the worktree's git dir", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: "gitdir: /repo/.git/worktrees/feature\n",
+    });
+
+    expect((await getGitHeadPath())?.toString()).toBe(
+      "file:///repo/.git/worktrees/feature/HEAD"
+    );
+  });
+
+  it("returns undefined when there is no .git", async () => {
+    expect(await getGitDir()).toBeUndefined();
+    expect(await getGitHeadPath()).toBeUndefined();
+  });
+});

--- a/src/test/load-config-for-path.test.ts
+++ b/src/test/load-config-for-path.test.ts
@@ -1,0 +1,127 @@
+import { loadConfigForPath } from "../config/config-manager";
+import {
+  __outputChannel,
+  __setFileSystem,
+  __setTextDocuments,
+} from "./vscode-stub";
+
+const ROOT = "file:///repo";
+
+beforeEach(() => {
+  __setFileSystem();
+  __setTextDocuments();
+});
+
+function load(wmPath: string) {
+  return loadConfigForPath(wmPath, ROOT, __outputChannel());
+}
+
+describe("loadConfigForPath", () => {
+  it("reads the root wmill.yaml for a nested script", async () => {
+    __setFileSystem({
+      [`${ROOT}/wmill.yaml`]: [
+        "defaultTs: deno",
+        "nonDottedPaths: true",
+        "codebases:",
+        "  - relative_path: bundle",
+        "workspaces:",
+        "  cm:",
+        "    baseUrl: https://windmill.example.net/",
+        "    gitBranch: main",
+        "    workspaceId: cm",
+      ].join("\n"),
+    });
+
+    const config = await load("f/some/deep/script");
+    expect(config.defaultTs).toBe("deno");
+    expect(config.nonDottedPaths).toBe(true);
+    expect(config.codebases).toEqual([{ relative_path: "bundle" }]);
+    expect(config.workspaces).toEqual({
+      cm: {
+        baseUrl: "https://windmill.example.net/",
+        gitBranch: "main",
+        workspaceId: "cm",
+      },
+    });
+  });
+
+  it("prefers the root wmill.yaml over one nearer the script", async () => {
+    // The search runs root-first and stops at the first hit
+    __setFileSystem({
+      [`${ROOT}/wmill.yaml`]: "defaultTs: deno",
+      [`${ROOT}/f/wmill.yaml`]: "defaultTs: bun",
+    });
+
+    expect((await load("f/some/script")).defaultTs).toBe("deno");
+  });
+
+  it("falls back to a wmill.yaml nearer the script", async () => {
+    __setFileSystem({ [`${ROOT}/f/wmill.yaml`]: "defaultTs: deno" });
+
+    expect((await load("f/some/script")).defaultTs).toBe("deno");
+  });
+
+  it("searches up to the script's own directory", async () => {
+    __setFileSystem({ [`${ROOT}/f/some/wmill.yaml`]: "defaultTs: deno" });
+
+    expect((await load("f/some/script")).defaultTs).toBe("deno");
+  });
+
+  it("returns defaults when there is no wmill.yaml", async () => {
+    const config = await load("f/some/script");
+    expect(config).toEqual({
+      defaultTs: "bun",
+      codebases: [],
+      workspaces: undefined,
+      nonDottedPaths: false,
+    });
+  });
+
+  it("returns defaults for an empty wmill.yaml", async () => {
+    __setFileSystem({ [`${ROOT}/wmill.yaml`]: "" });
+
+    const config = await load("f/some/script");
+    expect(config.defaultTs).toBe("bun");
+    expect(config.codebases).toEqual([]);
+    expect(config.workspaces).toBeUndefined();
+    expect(config.nonDottedPaths).toBe(false);
+  });
+
+  it("reads the deprecated gitBranches key", async () => {
+    __setFileSystem({
+      [`${ROOT}/wmill.yaml`]: [
+        "gitBranches:",
+        "  main:",
+        "    baseUrl: https://windmill.example.net/",
+        "    workspaceId: cm",
+      ].join("\n"),
+    });
+
+    expect((await load("f/some/script")).workspaces).toEqual({
+      main: { baseUrl: "https://windmill.example.net/", workspaceId: "cm" },
+    });
+  });
+
+  it("names the key it found in the log", async () => {
+    __setFileSystem({
+      [`${ROOT}/wmill.yaml`]: "environments:\n  main:\n    workspaceId: cm",
+    });
+
+    const channel = __outputChannel();
+    await loadConfigForPath("f/some/script", ROOT, channel);
+    expect(channel.lines.some((l: string) => l.includes("environments:"))).toBe(true);
+  });
+
+  it("uses unsaved editor changes to wmill.yaml over what is on disk", async () => {
+    __setFileSystem({ [`${ROOT}/wmill.yaml`]: "defaultTs: bun" });
+    __setTextDocuments({ [`${ROOT}/wmill.yaml`]: "defaultTs: deno" });
+
+    expect((await load("f/some/script")).defaultTs).toBe("deno");
+  });
+
+  it("handles a script at the repository root", async () => {
+    __setFileSystem({ [`${ROOT}/wmill.yaml`]: "defaultTs: deno" });
+
+    expect((await load("script")).defaultTs).toBe("deno");
+  });
+});

--- a/src/test/profile-resolution.test.ts
+++ b/src/test/profile-resolution.test.ts
@@ -1,0 +1,118 @@
+import { switchWorkspaceForBranch } from "../workspace/workspace-manager";
+import { WorkspacesConfig } from "../config/config-manager";
+import { getLastUsedProfile } from "../config/branch-profiles";
+import {
+  __configuration,
+  __informationMessages,
+  __resetConfiguration,
+} from "./vscode-stub";
+
+jest.mock("../config/branch-profiles", () => ({
+  getLastUsedProfile: jest.fn(),
+}));
+
+const mockedGetLastUsedProfile = getLastUsedProfile as jest.MockedFunction<
+  typeof getLastUsedProfile
+>;
+
+const REMOTE = "https://windmill.example.net/";
+
+// Two profiles for the same workspace on the same instance, differing only by
+// token — i.e. the same workspace reached as two different identities.
+const PERSONAL = { name: "cm-personal", remote: REMOTE, workspaceId: "cm", token: "t1" };
+const SERVICE = { name: "cm-service", remote: REMOTE, workspaceId: "cm", token: "t2" };
+
+const workspaces: WorkspacesConfig = {
+  cm: { baseUrl: REMOTE, gitBranch: "main", workspaceId: "cm" },
+};
+
+beforeEach(() => {
+  mockedGetLastUsedProfile.mockReset();
+  __informationMessages.length = 0;
+  __resetConfiguration({
+    additionalWorkspaces: [PERSONAL, SERVICE],
+    currentWorkspace: "other",
+  });
+});
+
+describe("resolving between several matching workspaces", () => {
+  it("follows the choice the CLI remembered", async () => {
+    mockedGetLastUsedProfile.mockResolvedValue("cm-service");
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-service");
+    // Keyed by the wmill.yaml workspace name, its baseUrl and workspace id
+    expect(mockedGetLastUsedProfile).toHaveBeenCalledWith("cm", REMOTE, "cm", undefined);
+    // Not ambiguous once resolved: no extra nudge in the notification
+    expect(__informationMessages).toEqual(['Switched to workspace "cm-service"']);
+  });
+
+  it("passes the configFolder override through to the CLI config lookup", async () => {
+    __resetConfiguration({
+      additionalWorkspaces: [PERSONAL, SERVICE],
+      currentWorkspace: "other",
+      configFolder: "/custom/config",
+    });
+    mockedGetLastUsedProfile.mockResolvedValue("cm-service");
+
+    await switchWorkspaceForBranch("main", workspaces);
+    expect(mockedGetLastUsedProfile).toHaveBeenCalledWith("cm", REMOTE, "cm", "/custom/config");
+  });
+
+  it("falls back to the first match and says so when nothing is remembered", async () => {
+    mockedGetLastUsedProfile.mockResolvedValue(undefined);
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-personal");
+    expect(__informationMessages[0]).toContain("cm-personal");
+    expect(__informationMessages[0]).toContain("Windmill: Switch workspace");
+  });
+
+  it("falls back when the remembered profile is no longer configured", async () => {
+    mockedGetLastUsedProfile.mockResolvedValue("cm-deleted");
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-personal");
+    expect(__informationMessages[0]).toContain("Windmill: Switch workspace");
+  });
+
+  it("does not consult the CLI config when only one workspace matches", async () => {
+    __resetConfiguration({ additionalWorkspaces: [PERSONAL], currentWorkspace: "other" });
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-personal");
+    expect(mockedGetLastUsedProfile).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when already on the resolved workspace", async () => {
+    __resetConfiguration({
+      additionalWorkspaces: [PERSONAL, SERVICE],
+      currentWorkspace: "cm-service",
+    });
+    mockedGetLastUsedProfile.mockResolvedValue("cm-service");
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__informationMessages).toEqual([]);
+  });
+
+  it("keeps working when the CLI config cannot be read", async () => {
+    mockedGetLastUsedProfile.mockRejectedValue(new Error("EACCES"));
+
+    // The read is best-effort, but a rejection must not leave the workspace unswitched
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-personal");
+  });
+
+  it("resolves the parent identity before deriving a fork workspace", async () => {
+    mockedGetLastUsedProfile.mockResolvedValue("cm-service");
+
+    expect(await switchWorkspaceForBranch("wm-fork/main/abc", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-service/wm-fork-abc");
+
+    const registered = __configuration().additionalWorkspaces.find(
+      (w: any) => w.name === "cm-service/wm-fork-abc"
+    );
+    // The fork inherits the chosen identity's token, not the first match's
+    expect(registered.token).toBe("t2");
+  });
+});

--- a/src/test/profile-resolution.test.ts
+++ b/src/test/profile-resolution.test.ts
@@ -4,6 +4,7 @@ import { getLastUsedProfile } from "../config/branch-profiles";
 import {
   __configuration,
   __informationMessages,
+  __outputChannel,
   __resetConfiguration,
 } from "./vscode-stub";
 
@@ -62,10 +63,17 @@ describe("resolving between several matching workspaces", () => {
   it("falls back to the first match and says so when nothing is remembered", async () => {
     mockedGetLastUsedProfile.mockResolvedValue(undefined);
 
-    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    const channel = __outputChannel();
+    expect(await switchWorkspaceForBranch("main", workspaces, channel)).toBe(true);
     expect(__configuration().currentWorkspace).toBe("cm-personal");
     expect(__informationMessages[0]).toContain("cm-personal");
     expect(__informationMessages[0]).toContain("Windmill: Switch workspace");
+    // The log names every candidate so the user can tell them apart
+    expect(
+      channel.lines.some(
+        (l: string) => l.includes("cm-personal") && l.includes("cm-service")
+      )
+    ).toBe(true);
   });
 
   it("falls back when the remembered profile is no longer configured", async () => {

--- a/src/test/switch-workspace-for-branch.test.ts
+++ b/src/test/switch-workspace-for-branch.test.ts
@@ -1,6 +1,15 @@
-import { switchWorkspaceForBranch } from "../workspace/workspace-manager";
+import {
+  setGlobalStatusBarItem,
+  setWorkspaceStatus,
+  switchWorkspaceForBranch,
+} from "../workspace/workspace-manager";
 import { WorkspacesConfig } from "../config/config-manager";
-import { __configuration, __resetConfiguration } from "./vscode-stub";
+import {
+  __configuration,
+  __failConfigurationUpdates,
+  __outputChannel,
+  __resetConfiguration,
+} from "./vscode-stub";
 
 const REMOTE = "https://windmill.example.net/";
 
@@ -127,6 +136,60 @@ describe("switchWorkspaceForBranch", () => {
 
     expect(await switchWorkspaceForBranch("commonSpecificItems", workspaces)).toBe(false);
     expect(__configuration().currentWorkspace).toBe("ir");
+  });
+});
+
+describe("switchWorkspaceForBranch failure handling", () => {
+  it("matches a baseUrl that is not a parseable URL", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm", "windmill.example.net")]));
+    const workspaces: WorkspacesConfig = {
+      cm: { baseUrl: "windmill.example.net", gitBranch: "main" },
+    };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-prod");
+  });
+
+  it("reports a failed settings write instead of throwing", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    __failConfigurationUpdates(new Error("settings are read-only"));
+    const workspaces: WorkspacesConfig = { cm: { baseUrl: REMOTE, gitBranch: "main" } };
+
+    const channel = __outputChannel();
+    expect(await switchWorkspaceForBranch("main", workspaces, channel)).toBe(false);
+    expect(
+      channel.lines.some((l: string) => l.includes("settings are read-only"))
+    ).toBe(true);
+  });
+});
+
+describe("the workspace status bar", () => {
+  it("shows the selected workspace", () => {
+    __resetConfiguration({ currentWorkspace: "cm-prod" });
+    const item = { text: "", show: jest.fn() };
+
+    setGlobalStatusBarItem(item as any);
+    setWorkspaceStatus();
+
+    expect(item.text).toBe("WM: cm-prod");
+    expect(item.show).toHaveBeenCalled();
+  });
+
+  it("falls back to main when no workspace is selected", () => {
+    __resetConfiguration();
+    const item = { text: "", show: jest.fn() };
+
+    setWorkspaceStatus(item as any);
+    expect(item.text).toBe("WM: main");
+  });
+
+  it("is updated when the branch switches the workspace", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    const item = { text: "", show: jest.fn() };
+    setGlobalStatusBarItem(item as any);
+
+    await switchWorkspaceForBranch("main", { cm: { baseUrl: REMOTE, gitBranch: "main" } });
+    expect(item.text).toBe("WM: cm-prod");
   });
 });
 

--- a/src/test/switch-workspace-for-branch.test.ts
+++ b/src/test/switch-workspace-for-branch.test.ts
@@ -1,0 +1,213 @@
+import { switchWorkspaceForBranch } from "../workspace/workspace-manager";
+import { WorkspacesConfig } from "../config/config-manager";
+import { __configuration, __resetConfiguration } from "./vscode-stub";
+
+const REMOTE = "https://windmill.example.net/";
+
+/** A CLI-synced workspace profile as it lands in `additionalWorkspaces`. */
+function profile(name: string, workspaceId: string, remote = REMOTE) {
+  return { name, remote, workspaceId, token: `token-${name}` };
+}
+
+/**
+ * Settings with no top-level remote/workspaceId/token, so that
+ * getWorkspacesFromVSCodeConfig doesn't add a synthetic "main" entry.
+ */
+function settings(additionalWorkspaces: any[], currentWorkspace = "other") {
+  return { additionalWorkspaces, currentWorkspace };
+}
+
+beforeEach(() => {
+  __resetConfiguration();
+});
+
+describe("switchWorkspaceForBranch", () => {
+  it("switches to the profile bound to the branch", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")]));
+    const workspaces: WorkspacesConfig = {
+      cm: { baseUrl: REMOTE, gitBranch: "main", workspaceId: "cm" },
+    };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    // The profile name, not the wmill.yaml workspace name
+    expect(__configuration().currentWorkspace).toBe("cm-prod");
+  });
+
+  it("defaults workspaceId to the workspace name", async () => {
+    __resetConfiguration(settings([profile("staging-profile", "staging")]));
+    const workspaces: WorkspacesConfig = { staging: { baseUrl: REMOTE } };
+
+    expect(await switchWorkspaceForBranch("staging", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("staging-profile");
+  });
+
+  it("matches remotes that differ only by trailing slash", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm", "https://windmill.example.net")]));
+    const workspaces: WorkspacesConfig = {
+      cm: { baseUrl: "https://windmill.example.net", gitBranch: "main" },
+    };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-prod");
+  });
+
+  it("keeps the current workspace when the branch is not configured", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    const workspaces: WorkspacesConfig = { cm: { baseUrl: REMOTE, gitBranch: "main" } };
+
+    expect(await switchWorkspaceForBranch("dev", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+
+  it("keeps the current workspace when no profile matches", async () => {
+    __resetConfiguration(settings([profile("other-instance", "cm", "https://other.example.net/")], "ir"));
+    const workspaces: WorkspacesConfig = { cm: { baseUrl: REMOTE, gitBranch: "main" } };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+
+  it("keeps the current workspace when the entry has no baseUrl", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    const workspaces: WorkspacesConfig = { cm: { gitBranch: "main", workspaceId: "cm" } };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+
+  it("is a no-op when already on the target workspace", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "cm-prod"));
+    const workspaces: WorkspacesConfig = { cm: { baseUrl: REMOTE, gitBranch: "main" } };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-prod");
+  });
+
+  it("does nothing without a branch or a workspaces config", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    expect(await switchWorkspaceForBranch("", { cm: { baseUrl: REMOTE } })).toBe(false);
+    expect(await switchWorkspaceForBranch("main", undefined)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+
+  it("uses the first workspace when several map to the same branch", async () => {
+    // The CLI warns and uses the first; this documents the same precedence here.
+    __resetConfiguration(settings([profile("first", "one"), profile("second", "two")]));
+    const workspaces: WorkspacesConfig = {
+      one: { baseUrl: REMOTE, gitBranch: "main" },
+      two: { baseUrl: REMOTE, gitBranch: "main" },
+    };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("first");
+  });
+
+  it("can select the top-level workspace when it has no CLI profile", async () => {
+    // With no additionalWorkspaces entry for it, the top-level settings are
+    // exposed as a synthetic "main" workspace.
+    __resetConfiguration({
+      additionalWorkspaces: [],
+      currentWorkspace: "other",
+      remote: REMOTE,
+      workspaceId: "cm",
+      token: "main-token",
+    });
+    const workspaces: WorkspacesConfig = { cm: { baseUrl: REMOTE, gitBranch: "main" } };
+
+    expect(await switchWorkspaceForBranch("main", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("main");
+  });
+
+  it("ignores the reserved commonSpecificItems key", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    const workspaces: WorkspacesConfig = {
+      commonSpecificItems: { settings: true } as any,
+      cm: { baseUrl: REMOTE, gitBranch: "main" },
+    };
+
+    expect(await switchWorkspaceForBranch("commonSpecificItems", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+});
+
+describe("switchWorkspaceForBranch on fork branches", () => {
+  const workspaces: WorkspacesConfig = {
+    cm: { baseUrl: REMOTE, gitBranch: "main", workspaceId: "cm" },
+  };
+
+  it("targets the fork workspace, reusing the parent's remote and auth", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+
+    expect(await switchWorkspaceForBranch("wm-fork/main/abc", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-prod/wm-fork-abc");
+
+    const registered = __configuration().additionalWorkspaces.find(
+      (w: any) => w.name === "cm-prod/wm-fork-abc"
+    );
+    expect(registered).toEqual({
+      name: "cm-prod/wm-fork-abc",
+      remote: REMOTE,
+      workspaceId: "wm-fork-abc",
+      token: "token-cm-prod",
+    });
+    // The parent profile is left untouched
+    expect(__configuration().additionalWorkspaces).toContainEqual(profile("cm-prod", "cm"));
+  });
+
+  it("re-registers the fork entry after a CLI sync wipes additionalWorkspaces", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+    await switchWorkspaceForBranch("wm-fork/main/abc", workspaces);
+
+    // syncVSCodeConfigFromCLI rewrites additionalWorkspaces from the CLI profiles,
+    // dropping the derived fork entry, and resets currentWorkspace to the CLI active one.
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+
+    expect(await switchWorkspaceForBranch("wm-fork/main/abc", workspaces)).toBe(true);
+    expect(__configuration().currentWorkspace).toBe("cm-prod/wm-fork-abc");
+    expect(
+      __configuration().additionalWorkspaces.filter(
+        (w: any) => w.name === "cm-prod/wm-fork-abc"
+      )
+    ).toHaveLength(1);
+  });
+
+  it("refreshes the fork entry when the parent's token changed", async () => {
+    __resetConfiguration(
+      settings(
+        [
+          profile("cm-prod", "cm"),
+          {
+            name: "cm-prod/wm-fork-abc",
+            remote: REMOTE,
+            workspaceId: "wm-fork-abc",
+            token: "stale-token",
+          },
+        ],
+        "ir"
+      )
+    );
+
+    expect(await switchWorkspaceForBranch("wm-fork/main/abc", workspaces)).toBe(true);
+    const registered = __configuration().additionalWorkspaces.find(
+      (w: any) => w.name === "cm-prod/wm-fork-abc"
+    );
+    expect(registered.token).toBe("token-cm-prod");
+    expect(__configuration().additionalWorkspaces).toHaveLength(2);
+  });
+
+  it("keeps the current workspace when the base branch is not configured", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+
+    expect(await switchWorkspaceForBranch("wm-fork/dev/abc", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+    expect(__configuration().additionalWorkspaces).toHaveLength(1);
+  });
+
+  it("treats a malformed fork branch as a plain branch", async () => {
+    __resetConfiguration(settings([profile("cm-prod", "cm")], "ir"));
+
+    // No fork id: must not silently fall through to the parent workspace
+    expect(await switchWorkspaceForBranch("wm-fork/main/", workspaces)).toBe(false);
+    expect(__configuration().currentWorkspace).toBe("ir");
+  });
+});

--- a/src/test/vscode-stub.ts
+++ b/src/test/vscode-stub.ts
@@ -1,17 +1,45 @@
 // Minimal stand-in for the `vscode` module so that unit tests can import
-// extension sources that pull it in at module load time.
+// extension sources that pull it in at module load time. The configuration is
+// backed by a mutable in-memory store so tests can drive and assert on the
+// settings the extension reads and writes.
+const configurationStore: Record<string, any> = {};
+
+/** Replace the whole configuration store. Call from `beforeEach`. */
+export function __resetConfiguration(values: Record<string, any> = {}) {
+  for (const key of Object.keys(configurationStore)) {
+    delete configurationStore[key];
+  }
+  Object.assign(configurationStore, values);
+}
+
+/** The current configuration, for assertions. */
+export function __configuration(): Record<string, any> {
+  return configurationStore;
+}
+
+/** Messages passed to `window.showInformationMessage`, for assertions. */
+export const __informationMessages: string[] = [];
+
 export const Uri = {
   parse: (value: string) => ({ toString: () => value }),
 };
 
 export const workspace = {
   fs: {},
-  getConfiguration: () => ({ get: () => undefined }),
+  getConfiguration: (_section?: string) => ({
+    get: (key: string) => configurationStore[key],
+    update: async (key: string, value: any, _target?: ConfigurationTarget) => {
+      configurationStore[key] = value;
+    },
+  }),
   workspaceFolders: undefined,
 };
 
 export const window = {
-  showInformationMessage: () => undefined,
+  showInformationMessage: (message: string) => {
+    __informationMessages.push(message);
+    return undefined;
+  },
   showErrorMessage: () => undefined,
 };
 

--- a/src/test/vscode-stub.ts
+++ b/src/test/vscode-stub.ts
@@ -1,0 +1,22 @@
+// Minimal stand-in for the `vscode` module so that unit tests can import
+// extension sources that pull it in at module load time.
+export const Uri = {
+  parse: (value: string) => ({ toString: () => value }),
+};
+
+export const workspace = {
+  fs: {},
+  getConfiguration: () => ({ get: () => undefined }),
+  workspaceFolders: undefined,
+};
+
+export const window = {
+  showInformationMessage: () => undefined,
+  showErrorMessage: () => undefined,
+};
+
+export enum ConfigurationTarget {
+  Global = 1,
+  Workspace = 2,
+  WorkspaceFolder = 3,
+}

--- a/src/test/vscode-stub.ts
+++ b/src/test/vscode-stub.ts
@@ -2,10 +2,15 @@
 // Names here mirror the `vscode` API surface, plus `__`-prefixed test hooks.
 //
 // Minimal stand-in for the `vscode` module so that unit tests can import
-// extension sources that pull it in at module load time. The configuration is
-// backed by a mutable in-memory store so tests can drive and assert on the
-// settings the extension reads and writes.
+// extension sources that pull it in at module load time. The configuration and
+// the filesystem are backed by mutable in-memory stores so tests can drive and
+// assert on what the extension reads and writes.
+
+// ---------------------------------------------------------------- configuration
+
 const configurationStore: Record<string, any> = {};
+
+let configurationUpdateError: Error | undefined;
 
 /** Replace the whole configuration store. Call from `beforeEach`. */
 export function __resetConfiguration(values: Record<string, any> = {}) {
@@ -13,6 +18,12 @@ export function __resetConfiguration(values: Record<string, any> = {}) {
     delete configurationStore[key];
   }
   Object.assign(configurationStore, values);
+  configurationUpdateError = undefined;
+}
+
+/** Make subsequent configuration writes fail, to exercise error handling. */
+export function __failConfigurationUpdates(error: Error) {
+  configurationUpdateError = error;
 }
 
 /** The current configuration, for assertions. */
@@ -23,20 +34,146 @@ export function __configuration(): Record<string, any> {
 /** Messages passed to `window.showInformationMessage`, for assertions. */
 export const __informationMessages: string[] = [];
 
-export const Uri = {
-  parse: (value: string) => ({ toString: () => value }),
+// ------------------------------------------------------------------ filesystem
+
+export enum FileType {
+  Unknown = 0,
+  File = 1,
+  Directory = 2,
+  SymbolicLink = 64,
+}
+
+/** Marks an entry of the in-memory filesystem as a directory. */
+export const __DIRECTORY = { directory: true } as const;
+
+type FileSystemEntry = string | typeof __DIRECTORY;
+
+const fileSystem = new Map<string, FileSystemEntry>();
+
+/**
+ * Collapse duplicate slashes and resolve `.`/`..`, the way a real filesystem
+ * does with the paths this extension builds by string concatenation.
+ */
+function normalizePath(path: string): string {
+  const isAbsolute = path.startsWith("/");
+  const resolved: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === ".." && resolved.length > 0 && resolved[resolved.length - 1] !== "..") {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+  return (isAbsolute ? "/" : "") + resolved.join("/");
+}
+
+function normalizeUriString(value: string): string {
+  const schemeEnd = value.indexOf("://");
+  if (schemeEnd === -1) {
+    return normalizePath(value);
+  }
+  const scheme = value.slice(0, schemeEnd + 3);
+  return scheme + normalizePath(value.slice(schemeEnd + 3));
+}
+
+/** Replace the whole in-memory filesystem. Keys are URI strings or paths. */
+export function __setFileSystem(entries: Record<string, FileSystemEntry> = {}) {
+  fileSystem.clear();
+  for (const [key, value] of Object.entries(entries)) {
+    fileSystem.set(normalizeUriString(key), value);
+  }
+}
+
+// ------------------------------------------------------------------------- Uri
+
+export type StubUri = {
+  scheme: string;
+  path: string;
+  fsPath: string;
+  toString(): string;
 };
 
+function makeUri(value: string): StubUri {
+  const normalized = normalizeUriString(value);
+  const schemeEnd = normalized.indexOf("://");
+  const scheme = schemeEnd === -1 ? "file" : normalized.slice(0, schemeEnd);
+  const path = schemeEnd === -1 ? normalized : normalized.slice(schemeEnd + 2);
+  return {
+    scheme,
+    path,
+    fsPath: path,
+    toString: () => normalized,
+  };
+}
+
+export const Uri = {
+  parse: (value: string): StubUri => makeUri(value),
+  file: (path: string): StubUri => makeUri(`file://${path}`),
+  joinPath: (base: StubUri, ...segments: string[]): StubUri =>
+    makeUri([base.toString(), ...segments].join("/")),
+};
+
+// ------------------------------------------------------------------- documents
+
+type StubTextDocument = { uri: StubUri; getText(): string };
+
+const textDocuments: StubTextDocument[] = [];
+
+/** Replace the set of open editor documents (used for unsaved buffers). */
+export function __setTextDocuments(docs: Record<string, string> = {}) {
+  textDocuments.length = 0;
+  for (const [uri, text] of Object.entries(docs)) {
+    textDocuments.push({ uri: makeUri(uri), getText: () => text });
+  }
+}
+
+// ------------------------------------------------------------------- workspace
+
 export const workspace = {
-  fs: {},
+  fs: {
+    stat: async (uri: StubUri) => {
+      const entry = fileSystem.get(uri.toString());
+      if (entry === undefined) {
+        throw new Error(`ENOENT: ${uri.toString()}`);
+      }
+      return typeof entry === "string"
+        ? { type: FileType.File, size: entry.length }
+        : { type: FileType.Directory, size: 0 };
+    },
+    readFile: async (uri: StubUri) => {
+      const entry = fileSystem.get(uri.toString());
+      if (typeof entry !== "string") {
+        throw new Error(`ENOENT: ${uri.toString()}`);
+      }
+      return new TextEncoder().encode(entry);
+    },
+    readDirectory: async (_uri: StubUri): Promise<[string, FileType][]> => [],
+  },
+  get textDocuments() {
+    return textDocuments;
+  },
   getConfiguration: (_section?: string) => ({
     get: (key: string) => configurationStore[key],
     update: async (key: string, value: any, _target?: ConfigurationTarget) => {
+      if (configurationUpdateError) {
+        throw configurationUpdateError;
+      }
       configurationStore[key] = value;
     },
   }),
-  workspaceFolders: undefined,
+  getWorkspaceFolder: (_uri: StubUri) => undefined,
+  workspaceFolders: undefined as { uri: StubUri }[] | undefined,
 };
+
+/** Set the workspace folders `getGitDir` and friends resolve against. */
+export function __setWorkspaceFolders(uris: string[]) {
+  workspace.workspaceFolders = uris.length
+    ? uris.map((uri) => ({ uri: makeUri(uri) }))
+    : undefined;
+}
 
 export const window = {
   showInformationMessage: (message: string) => {
@@ -50,4 +187,16 @@ export enum ConfigurationTarget {
   Global = 1,
   Workspace = 2,
   WorkspaceFolder = 3,
+}
+
+/** An OutputChannel that records what was written to it. */
+export function __outputChannel(): any & { lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    appendLine: (line: string) => lines.push(line),
+    append: (value: string) => lines.push(value),
+    show: () => undefined,
+    dispose: () => undefined,
+  };
 }

--- a/src/test/vscode-stub.ts
+++ b/src/test/vscode-stub.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+// Names here mirror the `vscode` API surface, plus `__`-prefixed test hooks.
+//
 // Minimal stand-in for the `vscode` module so that unit tests can import
 // extension sources that pull it in at module load time. The configuration is
 // backed by a mutable in-memory store so tests can drive and assert on the

--- a/src/test/web-environment.test.ts
+++ b/src/test/web-environment.test.ts
@@ -1,0 +1,45 @@
+import { getLastUsedProfile } from "../config/branch-profiles";
+import { getCurrentGitBranch, getGitDir } from "../utils/git-utils";
+import { getWorkspacesFromConfig } from "../workspace/workspace-manager";
+import { __DIRECTORY, __setFileSystem, __setWorkspaceFolders } from "./vscode-stub";
+
+// In the web extension host there is no node filesystem: the webpack build
+// stubs `fs` out entirely, so every path that would touch it must bail out on
+// this check rather than throwing.
+const originalVersions = process.versions;
+const ROOT = "file:///repo";
+
+beforeEach(() => {
+  __setWorkspaceFolders([ROOT]);
+  __setFileSystem({
+    [`${ROOT}/.git`]: __DIRECTORY,
+    [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+  });
+  jest.spyOn(console, "log").mockImplementation(() => undefined);
+  Object.defineProperty(process, "versions", { value: undefined, configurable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "versions", {
+    value: originalVersions,
+    configurable: true,
+  });
+  jest.restoreAllMocks();
+});
+
+describe("without a node runtime", () => {
+  it("reads no CLI workspaces", async () => {
+    expect(await getWorkspacesFromConfig()).toEqual({ workspaces: [], active: "" });
+  });
+
+  it("reads no remembered profile", async () => {
+    expect(
+      await getLastUsedProfile("cm", "https://windmill.example.net/", "cm")
+    ).toBeUndefined();
+  });
+
+  it("detects no git branch, even with a .git present", async () => {
+    expect(await getCurrentGitBranch()).toBeUndefined();
+    expect(await getGitDir()).toBeUndefined();
+  });
+});

--- a/src/test/workspace-config-resolution.test.ts
+++ b/src/test/workspace-config-resolution.test.ts
@@ -1,0 +1,254 @@
+import {
+  checkAndSwitchWorkspaceForGitBranch,
+  getCurrentWorkspaceConfig,
+  getWorkspacesFromVSCodeConfig,
+} from "../workspace/workspace-manager";
+import {
+  __DIRECTORY,
+  __outputChannel,
+  __resetConfiguration,
+  __setFileSystem,
+  __setTextDocuments,
+  __setWorkspaceFolders,
+} from "./vscode-stub";
+
+const ROOT = "file:///repo";
+const REMOTE = "https://windmill.example.net/";
+
+beforeEach(() => {
+  __resetConfiguration();
+  __setFileSystem();
+  __setTextDocuments();
+  __setWorkspaceFolders([ROOT]);
+});
+
+describe("getCurrentWorkspaceConfig", () => {
+  it("uses the top-level settings for the main workspace", () => {
+    __resetConfiguration({
+      currentWorkspace: "main",
+      remote: REMOTE,
+      workspaceId: "cm",
+      token: "main-token",
+    });
+
+    expect(getCurrentWorkspaceConfig()).toEqual({
+      token: "main-token",
+      workspace: "cm",
+      remoteUrl: REMOTE,
+      currentWorkspace: "main",
+    });
+  });
+
+  it("defaults to the main workspace when none is selected", () => {
+    __resetConfiguration({ remote: REMOTE, workspaceId: "cm", token: "main-token" });
+
+    expect(getCurrentWorkspaceConfig().currentWorkspace).toBe("main");
+  });
+
+  it("appends a trailing slash to the remote", () => {
+    __resetConfiguration({
+      currentWorkspace: "main",
+      remote: "https://windmill.example.net",
+      workspaceId: "cm",
+      token: "main-token",
+    });
+
+    expect(getCurrentWorkspaceConfig().remoteUrl).toBe(REMOTE);
+  });
+
+  it("uses the named workspace when one is selected", () => {
+    __resetConfiguration({
+      currentWorkspace: "cm-prod",
+      remote: "https://other.example.net/",
+      workspaceId: "other",
+      token: "other-token",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    expect(getCurrentWorkspaceConfig()).toEqual({
+      token: "cm-token",
+      workspace: "cm",
+      remoteUrl: REMOTE,
+      currentWorkspace: "cm-prod",
+    });
+  });
+
+  it("throws when the selected workspace is not configured", () => {
+    __resetConfiguration({ currentWorkspace: "gone", additionalWorkspaces: [] });
+
+    expect(() => getCurrentWorkspaceConfig()).toThrow("gone");
+  });
+});
+
+describe("getWorkspacesFromVSCodeConfig", () => {
+  it("exposes the top-level settings as a synthetic main workspace", () => {
+    __resetConfiguration({
+      remote: REMOTE,
+      workspaceId: "cm",
+      token: "main-token",
+      additionalWorkspaces: [],
+    });
+
+    expect(getWorkspacesFromVSCodeConfig()).toEqual([
+      { name: "main", remote: REMOTE, workspaceId: "cm", token: "main-token" },
+    ]);
+  });
+
+  it("omits the synthetic entry when a profile already covers it", () => {
+    // After a CLI sync the top-level settings duplicate the active profile; a
+    // synthetic "main" would shadow that profile's real name.
+    __resetConfiguration({
+      remote: "https://windmill.example.net",
+      workspaceId: "cm",
+      token: "cm-token",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    expect(getWorkspacesFromVSCodeConfig().map((w) => w.name)).toEqual(["cm-prod"]);
+  });
+
+  it("returns only the profiles when the top-level settings are incomplete", () => {
+    __resetConfiguration({
+      remote: REMOTE,
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    expect(getWorkspacesFromVSCodeConfig().map((w) => w.name)).toEqual(["cm-prod"]);
+  });
+});
+
+describe("checkAndSwitchWorkspaceForGitBranch", () => {
+  const wmillYaml = [
+    "workspaces:",
+    "  cm:",
+    "    baseUrl: https://windmill.example.net/",
+    "    gitBranch: main",
+    "    workspaceId: cm",
+  ].join("\n");
+
+  function onBranch(branch: string) {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: `ref: refs/heads/${branch}\n`,
+      [`${ROOT}/wmill.yaml`]: wmillYaml,
+    });
+  }
+
+  it("loads wmill.yaml and switches for the current branch", async () => {
+    onBranch("main");
+    __resetConfiguration({
+      currentWorkspace: "ir",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    const result = await checkAndSwitchWorkspaceForGitBranch(__outputChannel(), undefined);
+    expect(result.switched).toBe(true);
+    // The loaded config is handed back for caching
+    expect(result.config).toEqual({
+      cm: { baseUrl: REMOTE, gitBranch: "main", workspaceId: "cm" },
+    });
+  });
+
+  it("uses the cached config instead of re-reading wmill.yaml", async () => {
+    // Only .git exists: a reload would find no config and not switch
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+    });
+    __resetConfiguration({
+      currentWorkspace: "ir",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    const cached = { cm: { baseUrl: REMOTE, gitBranch: "main", workspaceId: "cm" } };
+    const result = await checkAndSwitchWorkspaceForGitBranch(__outputChannel(), cached);
+    expect(result.switched).toBe(true);
+  });
+
+  it("does nothing outside a git repository", async () => {
+    __setFileSystem({ [`${ROOT}/wmill.yaml`]: wmillYaml });
+
+    const channel = __outputChannel();
+    expect(await checkAndSwitchWorkspaceForGitBranch(channel, undefined)).toEqual({
+      switched: false,
+    });
+    expect(channel.lines).toContain("No git branch detected or not in a git repository");
+  });
+
+  it("does nothing without a workspace folder", async () => {
+    onBranch("main");
+    __setWorkspaceFolders([]);
+
+    expect(await checkAndSwitchWorkspaceForGitBranch(__outputChannel(), undefined)).toEqual(
+      { switched: false }
+    );
+  });
+
+  it("reports when wmill.yaml has no workspaces section", async () => {
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+      [`${ROOT}/wmill.yaml`]: "defaultTs: bun",
+    });
+
+    const channel = __outputChannel();
+    const result = await checkAndSwitchWorkspaceForGitBranch(channel, undefined);
+    expect(result).toEqual({ switched: false, config: undefined });
+    expect(channel.lines).toContain("No workspaces configuration found in wmill.yaml");
+  });
+
+  it("keeps the current workspace on an unconfigured branch", async () => {
+    onBranch("dev");
+    __resetConfiguration({
+      currentWorkspace: "ir",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    const result = await checkAndSwitchWorkspaceForGitBranch(__outputChannel(), undefined);
+    expect(result.switched).toBe(false);
+    // The config is still cached for the next check
+    expect(result.config).toBeDefined();
+  });
+
+  it("survives a wmill.yaml that is not valid YAML", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    __setFileSystem({
+      [`${ROOT}/.git`]: __DIRECTORY,
+      [`${ROOT}/.git/HEAD`]: "ref: refs/heads/main\n",
+      [`${ROOT}/wmill.yaml`]: "workspaces:\n  cm:\n   baseUrl: [unclosed\n",
+    });
+
+    const channel = __outputChannel();
+    const result = await checkAndSwitchWorkspaceForGitBranch(channel, undefined);
+    expect(result).toEqual({ switched: false });
+    expect(
+      channel.lines.some((l: string) => l.includes("Error checking git branch"))
+    ).toBe(true);
+    jest.restoreAllMocks();
+  });
+
+  it("switches to the fork workspace on a fork branch", async () => {
+    onBranch("wm-fork/main/abc");
+    __resetConfiguration({
+      currentWorkspace: "ir",
+      additionalWorkspaces: [
+        { name: "cm-prod", remote: REMOTE, workspaceId: "cm", token: "cm-token" },
+      ],
+    });
+
+    const result = await checkAndSwitchWorkspaceForGitBranch(__outputChannel(), undefined);
+    expect(result.switched).toBe(true);
+  });
+});

--- a/src/test/workspaces-config.test.ts
+++ b/src/test/workspaces-config.test.ts
@@ -4,6 +4,10 @@ import {
   getEffectiveGitBranch,
   getEffectiveWorkspaceId,
 } from "../config/config-manager";
+import {
+  getOriginalBranchForWorkspaceForks,
+  getWorkspaceIdForWorkspaceForkFromBranchName,
+} from "../utils/git-utils";
 
 describe("extractWorkspacesConfig", () => {
   it("reads the `workspaces` key", () => {
@@ -71,6 +75,41 @@ describe("findWorkspaceByGitBranch", () => {
   it("returns undefined for an unknown branch or missing config", () => {
     expect(findWorkspaceByGitBranch({ main: {} }, "dev")).toBeUndefined();
     expect(findWorkspaceByGitBranch(undefined, "main")).toBeUndefined();
+  });
+});
+
+describe("workspace fork branches", () => {
+  it("resolves the base branch and the fork workspace id", () => {
+    expect(getOriginalBranchForWorkspaceForks("wm-fork/main/abc")).toBe("main");
+    expect(getWorkspaceIdForWorkspaceForkFromBranchName("wm-fork/main/abc")).toBe(
+      "wm-fork-abc"
+    );
+  });
+
+  it("supports base branches containing slashes", () => {
+    expect(getOriginalBranchForWorkspaceForks("wm-fork/feat/foo/abc")).toBe("feat/foo");
+    expect(getWorkspaceIdForWorkspaceForkFromBranchName("wm-fork/feat/foo/abc")).toBe(
+      "wm-fork-abc"
+    );
+  });
+
+  it("returns undefined for non-fork and malformed branches", () => {
+    for (const branch of [undefined, "main", "wm-fork", "wm-fork/main", "wm-fork/main/"]) {
+      expect(getOriginalBranchForWorkspaceForks(branch)).toBeUndefined();
+      expect(getWorkspaceIdForWorkspaceForkFromBranchName(branch)).toBeUndefined();
+    }
+  });
+
+  it("looks the base branch up in wmill.yaml, not the fork branch", () => {
+    // The base branch entry only supplies the remote; the target workspace id
+    // comes from the branch name.
+    const workspaces = {
+      cm: { baseUrl: "https://windmill.example.net/", gitBranch: "main", workspaceId: "cm" },
+    };
+    const branch = "wm-fork/main/abc";
+    const base = getOriginalBranchForWorkspaceForks(branch)!;
+    expect(findWorkspaceByGitBranch(workspaces, branch)).toBeUndefined();
+    expect(findWorkspaceByGitBranch(workspaces, base)?.[0]).toBe("cm");
   });
 });
 

--- a/src/test/workspaces-config.test.ts
+++ b/src/test/workspaces-config.test.ts
@@ -1,0 +1,87 @@
+import {
+  extractWorkspacesConfig,
+  findWorkspaceByGitBranch,
+  getEffectiveGitBranch,
+  getEffectiveWorkspaceId,
+} from "../config/config-manager";
+
+describe("extractWorkspacesConfig", () => {
+  it("reads the `workspaces` key", () => {
+    const result = extractWorkspacesConfig({
+      workspaces: { cm: { baseUrl: "https://windmill.example.net/" } },
+    });
+    expect(result?.key).toBe("workspaces");
+    expect(Object.keys(result!.workspaces)).toEqual(["cm"]);
+  });
+
+  it("falls back to the deprecated keys", () => {
+    for (const key of ["gitBranches", "environments", "git_branches"]) {
+      const result = extractWorkspacesConfig({
+        [key]: { main: { baseUrl: "https://windmill.example.net/", workspaceId: "cm" } },
+      });
+      expect(result?.key).toBe(key);
+      expect(result?.workspaces.main.workspaceId).toBe("cm");
+    }
+  });
+
+  it("prefers `workspaces` over the deprecated keys", () => {
+    const result = extractWorkspacesConfig({
+      workspaces: { cm: { baseUrl: "https://new.example.net/" } },
+      gitBranches: { main: { baseUrl: "https://old.example.net/" } },
+    });
+    expect(result?.key).toBe("workspaces");
+  });
+
+  it("returns undefined when no workspaces config is present", () => {
+    expect(extractWorkspacesConfig({ defaultTs: "bun" })).toBeUndefined();
+    expect(extractWorkspacesConfig(undefined)).toBeUndefined();
+  });
+});
+
+describe("findWorkspaceByGitBranch", () => {
+  it("matches on the explicit gitBranch of a workspace", () => {
+    // The workspace name (`cm`) differs from the branch it is bound to (`main`)
+    const workspaces = {
+      cm: {
+        baseUrl: "https://windmill.example.net/",
+        gitBranch: "main",
+        workspaceId: "cm",
+      },
+    };
+    const match = findWorkspaceByGitBranch(workspaces, "main");
+    expect(match?.[0]).toBe("cm");
+    expect(match?.[1].workspaceId).toBe("cm");
+    expect(findWorkspaceByGitBranch(workspaces, "cm")).toBeUndefined();
+  });
+
+  it("falls back to the workspace name when gitBranch is omitted", () => {
+    const workspaces = { main: { baseUrl: "https://windmill.example.net/" } };
+    expect(findWorkspaceByGitBranch(workspaces, "main")?.[0]).toBe("main");
+  });
+
+  it("ignores reserved keys", () => {
+    const workspaces = {
+      commonSpecificItems: { settings: true } as any,
+      main: { baseUrl: "https://windmill.example.net/" },
+    };
+    expect(findWorkspaceByGitBranch(workspaces, "commonSpecificItems")).toBeUndefined();
+    expect(findWorkspaceByGitBranch(workspaces, "main")?.[0]).toBe("main");
+  });
+
+  it("returns undefined for an unknown branch or missing config", () => {
+    expect(findWorkspaceByGitBranch({ main: {} }, "dev")).toBeUndefined();
+    expect(findWorkspaceByGitBranch(undefined, "main")).toBeUndefined();
+  });
+});
+
+describe("effective workspace fields", () => {
+  it("defaults gitBranch and workspaceId to the workspace name", () => {
+    expect(getEffectiveGitBranch("staging", {})).toBe("staging");
+    expect(getEffectiveWorkspaceId("staging", {})).toBe("staging");
+  });
+
+  it("uses the explicit values when set", () => {
+    expect(getEffectiveGitBranch("cm", { gitBranch: "main" })).toBe("main");
+    expect(getEffectiveWorkspaceId("cm", { workspaceId: "cm-prod" })).toBe("cm-prod");
+  });
+});

--- a/src/utils/git-utils.ts
+++ b/src/utils/git-utils.ts
@@ -1,6 +1,57 @@
 import * as vscode from "vscode";
 import { fileExists, readTextFromUri } from "./file-utils";
 
+// Branch prefix of workspace fork branches: `wm-fork/<base>/<id>`. The matching
+// *workspace id* prefix is `wm-fork-` (see the CLI's utils/git.ts).
+const WM_FORK_PREFIX = "wm-fork";
+
+/**
+ * Split a `wm-fork/<base>/<id>` branch into the base branch it was forked from
+ * and the id of the fork workspace it targets. The base may itself contain
+ * slashes. Returns undefined for any branch that isn't a well-formed fork branch.
+ */
+function parseForkBranch(
+  branchName: string | undefined
+): { base: string; forkWorkspaceId: string } | undefined {
+  if (!branchName || !branchName.startsWith(`${WM_FORK_PREFIX}/`)) {
+    return undefined;
+  }
+
+  const start = WM_FORK_PREFIX.length + 1;
+  const end = branchName.lastIndexOf("/");
+
+  if (end <= start) {
+    return undefined;
+  }
+
+  const id = branchName.slice(end + 1);
+  if (id.length === 0) {
+    return undefined;
+  }
+
+  return { base: branchName.slice(start, end), forkWorkspaceId: `${WM_FORK_PREFIX}-${id}` };
+}
+
+/**
+ * For a `wm-fork/<base>/<id>` branch, the base branch it was forked from.
+ * Returns undefined for any other branch.
+ */
+export function getOriginalBranchForWorkspaceForks(
+  branchName: string | undefined
+): string | undefined {
+  return parseForkBranch(branchName)?.base;
+}
+
+/**
+ * For a `wm-fork/<base>/<id>` branch, the id of the fork workspace it targets.
+ * Returns undefined for any other branch.
+ */
+export function getWorkspaceIdForWorkspaceForkFromBranchName(
+  branchName: string | undefined
+): string | undefined {
+  return parseForkBranch(branchName)?.forkWorkspaceId;
+}
+
 /**
  * Find the .git directory in the workspace
  */

--- a/src/workspace/workspace-manager.ts
+++ b/src/workspace/workspace-manager.ts
@@ -6,7 +6,11 @@ import {
   getEffectiveWorkspaceId,
   loadConfigForPath,
 } from "../config/config-manager";
-import { getCurrentGitBranch } from "../utils/git-utils";
+import {
+  getCurrentGitBranch,
+  getOriginalBranchForWorkspaceForks,
+  getWorkspaceIdForWorkspaceForkFromBranchName,
+} from "../utils/git-utils";
 
 let globalStatusBarItem: vscode.StatusBarItem | undefined = undefined;
 
@@ -263,6 +267,58 @@ function normalizeRemote(remote: string): string {
 }
 
 /**
+ * Register (or refresh) the derived workspace entry for a fork workspace: the
+ * parent's remote and auth, with the fork's workspace id. `syncVSCodeConfigFromCLI`
+ * rewrites `additionalWorkspaces` wholesale from the CLI profiles, so this runs
+ * after every sync to re-add the entry.
+ * @returns the name of the fork workspace entry
+ */
+async function ensureForkWorkspaceProfile(
+  parent: Workspace,
+  forkWorkspaceId: string,
+  branchName: string,
+  channel?: vscode.OutputChannel
+): Promise<string> {
+  const forkName = `${parent.name}/${forkWorkspaceId}`;
+  const entry = {
+    name: forkName,
+    remote: parent.remote,
+    workspaceId: forkWorkspaceId,
+    token: parent.token,
+  };
+
+  const conf = vscode.workspace.getConfiguration("windmill");
+  const additionalWorkspaces = ((conf.get("additionalWorkspaces") as any[]) ?? []).slice();
+  const existingIndex = additionalWorkspaces.findIndex((w) => w?.name === forkName);
+  const existing = existingIndex >= 0 ? additionalWorkspaces[existingIndex] : undefined;
+
+  const upToDate =
+    existing &&
+    existing.remote === entry.remote &&
+    existing.workspaceId === entry.workspaceId &&
+    existing.token === entry.token;
+
+  if (!upToDate) {
+    if (existingIndex >= 0) {
+      additionalWorkspaces[existingIndex] = entry;
+    } else {
+      additionalWorkspaces.push(entry);
+    }
+    await conf.update(
+      "additionalWorkspaces",
+      additionalWorkspaces,
+      vscode.ConfigurationTarget.Global
+    );
+    channel?.appendLine(
+      `Targeting fork workspace "${forkWorkspaceId}" (fork of "${parent.workspaceId}" on ${parent.remote}, ` +
+      `auth reused from workspace "${parent.name}"), resolved from git branch "${branchName}"`
+    );
+  }
+
+  return forkName;
+}
+
+/**
  * Switch workspace based on git branch configuration
  * @param branchName The current git branch name
  * @param workspacesConfig The workspaces configuration from wmill.yaml
@@ -279,9 +335,20 @@ export async function switchWorkspaceForBranch(
     return false;
   }
 
-  const match = findWorkspaceByGitBranch(workspacesConfig, branchName);
+  // On a `wm-fork/<base>/<id>` branch the target is the fork workspace, whose id
+  // comes from the branch name itself. wmill.yaml is only consulted for the base
+  // branch's entry, which supplies the remote (and, through its profile, the auth)
+  // the fork is reached with.
+  const forkBaseBranch = getOriginalBranchForWorkspaceForks(branchName);
+  const forkWorkspaceId = getWorkspaceIdForWorkspaceForkFromBranchName(branchName);
+  const lookupBranch = forkBaseBranch ?? branchName;
+
+  const match = findWorkspaceByGitBranch(workspacesConfig, lookupBranch);
   if (!match) {
-    channel?.appendLine(`No workspace configuration found for branch: ${branchName}. Keeping current workspace.`);
+    const via = forkBaseBranch
+      ? `${branchName} (base branch ${forkBaseBranch})`
+      : branchName;
+    channel?.appendLine(`No workspace configuration found for branch: ${via}. Keeping current workspace.`);
     return false;
   }
   const [wsName, branchWorkspace] = match;
@@ -316,18 +383,25 @@ export async function switchWorkspaceForBranch(
       return false;
     }
 
+    // The CLI never saves a profile for a fork workspace — it derives one from the
+    // parent's at command time. Do the same here, since switching requires a named
+    // workspace to exist in the VSCode configuration.
+    const targetName = forkWorkspaceId
+      ? await ensureForkWorkspaceProfile(matchingWorkspace, forkWorkspaceId, branchName, channel)
+      : matchingWorkspace.name;
+
     const conf = vscode.workspace.getConfiguration("windmill");
-    
+
     // Switch to the workspace using the name from config, if current workspace is not the same
-    if (conf.get("currentWorkspace") === matchingWorkspace.name) {
-      channel?.appendLine(`Already on workspace "${matchingWorkspace.name}"`);
+    if (conf.get("currentWorkspace") === targetName) {
+      channel?.appendLine(`Already on workspace "${targetName}"`);
       return true;
     }
 
-    await conf.update("currentWorkspace", matchingWorkspace.name, vscode.ConfigurationTarget.Global);
-    channel?.appendLine(`Switched to workspace "${matchingWorkspace.name}" for branch: ${branchName}`);
+    await conf.update("currentWorkspace", targetName, vscode.ConfigurationTarget.Global);
+    channel?.appendLine(`Switched to workspace "${targetName}" for branch: ${branchName}`);
     vscode.window.showInformationMessage(
-      `Switched to workspace "${matchingWorkspace.name}"`
+      `Switched to workspace "${targetName}"`
     );
     setWorkspaceStatus();
     return true;

--- a/src/workspace/workspace-manager.ts
+++ b/src/workspace/workspace-manager.ts
@@ -6,6 +6,7 @@ import {
   getEffectiveWorkspaceId,
   loadConfigForPath,
 } from "../config/config-manager";
+import { getLastUsedProfile } from "../config/branch-profiles";
 import {
   getCurrentGitBranch,
   getOriginalBranchForWorkspaceForks,
@@ -267,6 +268,63 @@ function normalizeRemote(remote: string): string {
 }
 
 /**
+ * Pick which of several workspaces sharing a remote and workspace id to use.
+ * They differ only by token, so this chooses the identity to act as: follow the
+ * choice the user already made in the CLI when there is one, rather than
+ * interrupting a background branch switch with a prompt.
+ * @returns the chosen workspace, and whether the choice was ambiguous and
+ * unresolved (worth surfacing to the user)
+ */
+async function resolveMatchingWorkspace(
+  candidates: Workspace[],
+  workspaceName: string,
+  normalizedBaseUrl: string,
+  workspaceId: string,
+  channel?: vscode.OutputChannel
+): Promise<{ workspace: Workspace; ambiguous: boolean }> {
+  if (candidates.length === 1) {
+    return { workspace: candidates[0], ambiguous: false };
+  }
+
+  const configFolder = vscode.workspace
+    .getConfiguration("windmill")
+    .get("configFolder") as string;
+
+  // Best-effort: a workspace we cannot read the CLI's choice from still switches,
+  // it just falls back to the first match below.
+  let lastUsedName: string | undefined;
+  try {
+    lastUsedName = await getLastUsedProfile(
+      workspaceName,
+      normalizedBaseUrl,
+      workspaceId,
+      configFolder
+    );
+  } catch (error) {
+    channel?.appendLine(`Could not read the CLI's last used profile: ${error}`);
+  }
+
+  const lastUsed = lastUsedName
+    ? candidates.find((w) => w.name === lastUsedName)
+    : undefined;
+
+  if (lastUsed) {
+    channel?.appendLine(
+      `${candidates.length} workspaces match "${workspaceId}" at "${normalizedBaseUrl}". ` +
+      `Using "${lastUsed.name}", last used by the CLI for workspace "${workspaceName}".`
+    );
+    return { workspace: lastUsed, ambiguous: false };
+  }
+
+  channel?.appendLine(
+    `${candidates.length} workspaces match "${workspaceId}" at "${normalizedBaseUrl}" ` +
+    `(${candidates.map((w) => w.name).join(", ")}) and the CLI has no remembered choice for ` +
+    `workspace "${workspaceName}". Using "${candidates[0].name}".`
+  );
+  return { workspace: candidates[0], ambiguous: true };
+}
+
+/**
  * Register (or refresh) the derived workspace entry for a fork workspace: the
  * parent's remote and auth, with the fork's workspace id. `syncVSCodeConfigFromCLI`
  * rewrites `additionalWorkspaces` wholesale from the CLI profiles, so this runs
@@ -370,18 +428,26 @@ export async function switchWorkspaceForBranch(
     const vscodeWorkspaces = getWorkspacesFromVSCodeConfig();
 
     // Check if this workspace exists in VSCode config
-    const matchingWorkspace = vscodeWorkspaces.find(
+    const matchingWorkspaces = vscodeWorkspaces.filter(
       (w: Workspace) =>
         normalizeRemote(w.remote) === normalizedBaseUrl && w.workspaceId === workspaceId
     );
 
-    if (!matchingWorkspace) {
+    if (matchingWorkspaces.length === 0) {
       channel?.appendLine(
         `Workspace "${workspaceId}" at "${normalizedBaseUrl}" not found in VSCode configuration. ` +
         `Please configure this workspace in VSCode settings before switching to branch "${branchName}".`
       );
       return false;
     }
+
+    const { workspace: matchingWorkspace, ambiguous } = await resolveMatchingWorkspace(
+      matchingWorkspaces,
+      wsName,
+      normalizedBaseUrl,
+      workspaceId,
+      channel
+    );
 
     // The CLI never saves a profile for a fork workspace — it derives one from the
     // parent's at command time. Do the same here, since switching requires a named
@@ -401,7 +467,9 @@ export async function switchWorkspaceForBranch(
     await conf.update("currentWorkspace", targetName, vscode.ConfigurationTarget.Global);
     channel?.appendLine(`Switched to workspace "${targetName}" for branch: ${branchName}`);
     vscode.window.showInformationMessage(
-      `Switched to workspace "${targetName}"`
+      ambiguous
+        ? `Switched to workspace "${targetName}". Several profiles match it — run "Windmill: Switch workspace" to pick another.`
+        : `Switched to workspace "${targetName}"`
     );
     setWorkspaceStatus();
     return true;

--- a/src/workspace/workspace-manager.ts
+++ b/src/workspace/workspace-manager.ts
@@ -1,6 +1,11 @@
 import * as vscode from "vscode";
 import { getWorkspaceConfigFilePath, getActiveWorkspaceConfigFilePath } from "windmill-utils-internal";
-import { GitBranchConfig, loadConfigForPath } from "../config/config-manager";
+import {
+  WorkspacesConfig,
+  findWorkspaceByGitBranch,
+  getEffectiveWorkspaceId,
+  loadConfigForPath,
+} from "../config/config-manager";
 import { getCurrentGitBranch } from "../utils/git-utils";
 
 let globalStatusBarItem: vscode.StatusBarItem | undefined = undefined;
@@ -197,13 +202,13 @@ export async function syncVSCodeConfigFromCLI(
 /**
  * Check the current git branch and switch workspace if configured
  * @param channel Output channel for logging
- * @param cachedGitBranchConfig Optional cached gitBranches config to avoid reloading
+ * @param cachedWorkspacesConfig Optional cached workspaces config to avoid reloading
  * @returns Object with switched status and loaded config for caching
  */
 export async function checkAndSwitchWorkspaceForGitBranch(
   channel: vscode.OutputChannel,
-  cachedGitBranchConfig: GitBranchConfig | undefined
-): Promise<{ switched: boolean; config?: GitBranchConfig }> {
+  cachedWorkspacesConfig: WorkspacesConfig | undefined
+): Promise<{ switched: boolean; config?: WorkspacesConfig }> {
   try {
     // Get current git branch
     const currentBranch = await getCurrentGitBranch();
@@ -214,10 +219,10 @@ export async function checkAndSwitchWorkspaceForGitBranch(
 
     channel.appendLine(`Current git branch: ${currentBranch}`);
 
-    let gitBranches = cachedGitBranchConfig;
+    let workspaces = cachedWorkspacesConfig;
 
     // If we don't have the config cached yet, load it
-    if (!gitBranches) {
+    if (!workspaces) {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders || workspaceFolders.length === 0) {
         channel.appendLine("No workspace folder found");
@@ -227,17 +232,17 @@ export async function checkAndSwitchWorkspaceForGitBranch(
       const rootPath = workspaceFolders[0].uri.toString();
       // Call loadConfigForPath with empty string to check root wmill.yaml
       const config = await loadConfigForPath("", rootPath, channel);
-      gitBranches = config.gitBranches;
+      workspaces = config.workspaces;
     }
 
-    if (!gitBranches) {
-      channel.appendLine("No gitBranches configuration found in wmill.yaml");
+    if (!workspaces) {
+      channel.appendLine("No workspaces configuration found in wmill.yaml");
       return { switched: false, config: undefined };
     }
 
     // Switch workspace based on branch (checks against VSCode config internally)
-    const switched = await switchWorkspaceForBranch(currentBranch, gitBranches, channel);
-    return { switched, config: gitBranches };
+    const switched = await switchWorkspaceForBranch(currentBranch, workspaces, channel);
+    return { switched, config: workspaces };
   } catch (error) {
     channel.appendLine(`Error checking git branch for workspace switch: ${error}`);
     console.error("Error checking git branch:", error);
@@ -246,45 +251,61 @@ export async function checkAndSwitchWorkspaceForGitBranch(
 }
 
 /**
+ * Normalize a remote URL the same way the CLI does when storing workspace
+ * profiles, so that config-file and settings-entered URLs compare equal.
+ */
+function normalizeRemote(remote: string): string {
+  try {
+    return new URL(remote).toString();
+  } catch {
+    return remote.endsWith("/") ? remote : remote + "/";
+  }
+}
+
+/**
  * Switch workspace based on git branch configuration
  * @param branchName The current git branch name
- * @param gitBranchConfig The gitBranches configuration from wmill.yaml
+ * @param workspacesConfig The workspaces configuration from wmill.yaml
  * @param channel Optional output channel for logging
  * @returns true if workspace was switched, false otherwise
  */
 export async function switchWorkspaceForBranch(
   branchName: string,
-  gitBranchConfig: GitBranchConfig | undefined,
+  workspacesConfig: WorkspacesConfig | undefined,
   channel?: vscode.OutputChannel
 ): Promise<boolean> {
-  if (!gitBranchConfig || !branchName) {
-    channel?.appendLine(`No git branch config or branch name provided. Skipping workspace switch.`);
+  if (!workspacesConfig || !branchName) {
+    channel?.appendLine(`No workspaces config or branch name provided. Skipping workspace switch.`);
     return false;
   }
 
-  const branchWorkspace = gitBranchConfig[branchName];
-  if (!branchWorkspace) {
+  const match = findWorkspaceByGitBranch(workspacesConfig, branchName);
+  if (!match) {
     channel?.appendLine(`No workspace configuration found for branch: ${branchName}. Keeping current workspace.`);
     return false;
   }
+  const [wsName, branchWorkspace] = match;
 
   try {
-    const { baseUrl, workspaceId } = branchWorkspace;
-    
-    if (!baseUrl || !workspaceId) {
-      channel?.appendLine(`Invalid workspace configuration for branch ${branchName}. Missing baseUrl or workspaceId.`);
+    const { baseUrl } = branchWorkspace;
+    const workspaceId = getEffectiveWorkspaceId(wsName, branchWorkspace);
+
+    if (!baseUrl) {
+      channel?.appendLine(
+        `Workspace "${wsName}" (branch ${branchName}) has no baseUrl in wmill.yaml. Cannot resolve a workspace to switch to.`
+      );
       return false;
     }
 
-    // Normalize the base URL to ensure it ends with /
-    const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+    const normalizedBaseUrl = normalizeRemote(baseUrl);
 
     // Get all workspaces from VSCode config (includes both CLI-synced and manually configured)
     const vscodeWorkspaces = getWorkspacesFromVSCodeConfig();
-    
+
     // Check if this workspace exists in VSCode config
     const matchingWorkspace = vscodeWorkspaces.find(
-      (w: Workspace) => w.remote === normalizedBaseUrl && w.workspaceId === workspaceId
+      (w: Workspace) =>
+        normalizeRemote(w.remote) === normalizedBaseUrl && w.workspaceId === workspaceId
     );
 
     if (!matchingWorkspace) {


### PR DESCRIPTION
Reported by a customer: after moving their `wmill.yaml` to the new `workspaces` key, the extension stopped picking up their workspace, logging `No gitBranches configuration found in wmill.yaml` and staying on whichever workspace the CLI had active.

```yaml
workspaces:
  cm:
    baseUrl: https://windmill.pagtech.net/
    gitBranch: main
    workspaceId: cm
```

## The bug

The extension read exactly one key, `config["gitBranches"]`, and looked the branch up as a **map key**. Both are wrong against today's CLI (`cli/src/core/conf.ts`):

- **Key name** — the primary key is `workspaces`; `gitBranches` / `environments` / `git_branches` are deprecated aliases the CLI normalizes in `readConfigFile`. The extension only knew the first alias, so the config was invisible.
- **Lookup** — in the new format the key is the *workspace name*; the branch is `entry.gitBranch ?? name`. Even via the legacy key, `config["main"]` would have missed an entry named `cm`.
- **workspaceId** now defaults to the workspace name (`getEffectiveWorkspaceId`); the extension required it explicitly.
- **Remote comparison** normalized only the config side, so a remote entered without a trailing slash never matched.

I verified the published 0.2.60 build has the same code — the exact string the customer saw is in the shipped bundle, so nothing was lost in an unreleased change.

## Also in here

**Fork branches.** On `wm-fork/<base>/<id>` the CLI targets the fork workspace `wm-fork-<id>`, resolved from the branch name; wmill.yaml is consulted only for the base branch's entry, which supplies the remote, and auth is reused from that workspace's profile. The CLI never *persists* a fork profile (it derives one in memory per command, `core/context.ts`), so there's nothing for `syncVSCodeConfigFromCLI` to pull in — the extension registers a derived entry itself, named `<parent>/wm-fork-<id>`, re-added after each sync since `additionalWorkspaces` is rewritten wholesale.

**Ambiguous profiles.** When several profiles share a remote and workspace id — the same workspace as different identities — the extension silently took the first. It now reads the choice the CLI remembered in `branch-profiles.json`. It deliberately does *not* prompt when there's no remembered choice: this runs from the `.git/HEAD` watcher and on activation, so a QuickPick would appear because you ran `git checkout`. It falls back to the first match and names it in the notification; `Windmill: Switch workspace` remains for choosing deliberately.

**Stale config.** The workspaces config was only reloaded when the active editor changed, so editing `wmill.yaml` had no effect until you switched files — plausibly the next thing to hit anyone who has just corrected that file. Now watched.

**`findCodebase`** returned `undefined` at the first codebase that didn't match, making every codebase after the first unreachable. The CLI's own `findCodebase` continues the loop; this now does too. Found while covering the module — the regression test fails against the previous behaviour.

## Testing

161 tests (from 46). `tsc --noEmit` clean, `npm run lint` 0 errors with no new warnings, and both bundles build (esbuild node + webpack web).

Statement coverage of the touched modules went from 73% to **99%** (100% functions, 95% branches):

| module | statements | branches |
|---|---|---|
| `config/config-manager.ts` | 100% | 100% |
| `config/branch-profiles.ts` | 100% | 87% |
| `utils/git-utils.ts` | 100% | 100% |
| `workspace/workspace-manager.ts` | 99% | 92% |

Git detection and config loading go through the **vscode** filesystem API rather than node's, so the test stub grew an in-memory filesystem, open-document set and workspace folders. `syncVSCodeConfigFromCLI` does use node `fs`, so it runs against a real temporary config dir laid out the way the CLI writes it — no fs mocking needed.

Covered: config key precedence across all three deprecated aliases; branch matching via `gitBranch` and via the name; `switchWorkspaceForBranch` end to end (profile match/non-match, `workspaceId` defaulting, trailing-slash and unparseable-URL normalization, missing `baseUrl`, already-on-target no-op, synthetic `main`, failed settings write); the fork cases (derived entry contents, re-registration after a sync wipe, parent token rotation, unconfigured base branch, malformed fork branch not falling through to the parent); the ambiguity cases (remembered choice honored, `configFolder` passed through, fallbacks, fork inheriting the *chosen* identity's token); `.git/HEAD` parsing including worktree gitdir indirection both absolute and relative, detached HEAD, and unreadable HEAD; the root-first `wmill.yaml` search and its precedence, plus unsaved editor buffers winning over disk; the CLI sync and its failure modes; `checkAndSwitchWorkspaceForGitBranch` including a `wmill.yaml` that isn't valid YAML; the web-environment guards that keep the webpack build from touching node `fs`; and the status bar.

The `branch-profiles.json` location (`<configDir>/0/`, from the CLI's `getStore("")`) is exercised against a real file written in the CLI's layout, and was additionally verified against the actual file the CLI wrote on my machine.

Three defects the tests caught and I fixed rather than shipped: the two fork-branch helpers disagreed on `wm-fork/main/` (empty id), which would have silently targeted the *parent* workspace — they now derive from one parser; a failed CLI-config read aborted the whole switch through the outer catch, now best-effort; and the `findCodebase` scan above.

**Uncovered by design:** `workspace-manager.ts:233-234`, a "no workspace folder" guard only reachable after `getCurrentGitBranch` already succeeded — which itself requires a workspace folder; and the default-config-dir branch of `getLastUsedProfile`, which would read the developer's real `~/.config/windmill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)